### PR TITLE
A fix for https://issues.jenkins-ci.org/browse/JENKINS-3922

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -646,6 +646,7 @@ public class SSHLauncher extends ComputerLauncher {
 
     protected void openConnection(TaskListener listener) throws IOException, InterruptedException {
         listener.getLogger().println(Messages.SSHLauncher_OpeningSSHConnection(getTimestamp(), host + ":" + port));
+        connection.setTCPNoDelay(true);
         connection.connect();
 
         String username = this.username;


### PR DESCRIPTION
A problem for me seems to be buffering on slave -> master ssh connection. We are sending messages in chunks ~5KB and buffer (especially for localhost connections) is higher. Fortunatelly, setting TCP_NODELAY fixes this
