### PR TITLE
Environment variables in java path.

### DIFF
--- a/src/main/resources/hudson/plugins/sshslaves/SSHConnector/help-javaPath.html
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHConnector/help-javaPath.html
@@ -2,4 +2,7 @@
     <p>This java Path will be used to start the jvm. (/mycustomjdkpath/bin/java )
        If empty Jenkins will search java command in the slave
     </p>
+    <p>Expressions such as $key or ${key} may be declared in the java Path and will be expanded to values of matching
+        keys declared in the list of environment variables of this node, or if not present, in the list of global
+        environment variables.</p>
 </div>


### PR DESCRIPTION
Allow environment variables to be declared in the java path, that are then expanded according to environment variables declared on the node or globally
