### PR TITLE
Integrate with ssh-credentials-plugin and credentials-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,18 @@
     </repository>
   </repositories>
 
+  <dependencies>
+    <!-- regular dependencies -->
+    <!-- plugin dependencies -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-credentials</artifactId>
+      <version>0.1</version>
+    </dependency>
+    <!-- jenkins dependencies -->
+    <!-- test dependencies -->
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config.jelly
@@ -1,16 +1,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:advanced>
-      <f:entry title="${%Username}" field="username">
-          <f:textbox />
-      </f:entry>
-
-      <f:entry title="${%Password}" field="password">
-        <f:password />
-      </f:entry>
-
-      <f:entry title="${%Private Key File}" field="privatekey">
-          <f:textbox />
+      <f:entry title="${%Credentials}" field="credentialsId">
+          <f:select/>
       </f:entry>
 
       <f:entry title="${%Port}" field="port">


### PR DESCRIPTION
Also fixed JENKINS-6714 (as opposed to just complaining that keyboard-interactive is not supported), i.e. keyboard-interactive now works.

Before merging it needs some checks that backwards compatability works, i.e. upgrading does not bork your system.

Also need to check that configuration is only locked in if you save the slave configuration... as long as you don't save, should be able to roll-back to previous version.

Might need that magic configuration in the pom to say what the data consistency version is
