### PR TITLE
Fixes link in help text for adding credentials

### DIFF
--- a/src/main/resources/hudson/plugins/sshslaves/SSHConnector/help-credentialsId.html
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHConnector/help-credentialsId.html
@@ -1,4 +1,4 @@
 <div>
-    Select the credentials to used for logging in to the remote host. You can <a href="../../credentials/">add some</a> if you need
+    Select the credentials to used for logging in to the remote host. You can <a href="${rootURL}/credentials/">add some</a> if you need
     to.
 </div>


### PR DESCRIPTION
The hardcoded '../../credentials' pointed to a wrong location if you have
Jenkins running e.g. 'on www.servername.com/ci'. The 'rootURL' handles
this.

Change-Id: I8b6d529aca31b5b7a28d02fde0c4b86b9dbb7b3c
Signed-off-by: Aske Olsson aske.olsson@switch-gears.dk
