### PR TITLE
Meaningful thread name for callable establishing SSH connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532</version>
+    <version>1.554</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -72,6 +72,7 @@ import hudson.tools.ToolLocationNodeProperty.ToolLocation;
 import hudson.util.DescribableList;
 import hudson.util.IOException2;
 import hudson.util.ListBoxModel;
+import hudson.util.NamingThreadFactory;
 import hudson.util.NullStream;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
@@ -701,7 +702,8 @@ public class SSHLauncher extends ComputerLauncher {
     @Override
     public synchronized void launch(final SlaveComputer computer, final TaskListener listener) throws InterruptedException {
         connection = new Connection(host, port);
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        ExecutorService executorService = Executors.newSingleThreadExecutor(
+                new NamingThreadFactory(Executors.defaultThreadFactory(), "SSHLauncher.launch for '" + computer.getName() + "' node"));
         Set<Callable<Boolean>> callables = new HashSet<Callable<Boolean>>();
         callables.add(new Callable<Boolean>() {
             public Boolean call() throws InterruptedException {


### PR DESCRIPTION
This is needed to diagnose slave connection initialization issues. Currently, SSH connection initialization is done in a  `Callable` running inside an anonymous and dedicated `ExecutorService`. If something goes wrong and connection timeout is set to 0, connection thread can get stuck and never killed. Without this, we can't find which slave is involved.

Bumping core dependency was required to use `NamingThreadFactory`.

@reviewbybees 
