### PR TITLE
[FIXED JENKINS-32489] "Prefix/Suffix Start Slave Command" does not add a space before/after the cmd

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -965,7 +965,7 @@ public class SSHLauncher extends ComputerLauncher {
         String cmd = "cd \"" + workingDirectory + "\" && " + java + " " + getJvmOptions() + " -jar slave.jar";
 
         //This will wrap the cmd with prefix commands and suffix commands if they are set.
-        cmd = getPrefixStartSlaveCmd() + cmd + getSuffixStartSlaveCmd();
+        cmd = getPrefixStartSlaveCmd() + " " + cmd + " " + getSuffixStartSlaveCmd();
 
         listener.getLogger().println(Messages.SSHLauncher_StartingSlaveProcess(getTimestamp(), cmd));
         session.execCommand(cmd);


### PR DESCRIPTION
Add the suffix below into a ssh-slave.

``` 
2> >(tee -a slave-stderr.log 1>&2)
```
Then, the following happens:

```
[01/18/16 08:32:37] [SSH] Copied 478,051 bytes.
Expanded the channel window size to 4MB
[01/18/16 08:32:37] [SSH] Starting slave process: cd "/home/vagrant" && java  -jar slave.jar2> >(tee -a slave-stderr.log 1>&2)
Unable to access jarfile slave.jar2
hudson.util.IOException2: Slave JVM has terminated. Exit code=1
	at hudson.plugins.sshslaves.SSHLauncher.startSlave(SSHLauncher.java:953)
	at hudson.plugins.sshslaves.SSHLauncher.access$400(SSHLauncher.java:133)
	at hudson.plugins.sshslaves.SSHLauncher$2.call(SSHLauncher.java:711)
	at hudson.plugins.sshslaves.SSHLauncher$2.call(SSHLauncher.java:696)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.EOFException: unexpected stream termination
	at hudson.remoting.ChannelBuilder.negotiate(ChannelBuilder.java:331)
	at hudson.remoting.ChannelBuilder.build(ChannelBuilder.java:280)
	at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:371)
	at hudson.plugins.sshslaves.SSHLauncher.startSlave(SSHLauncher.java:945)
	... 7 more
[01/18/16 08:32:37] Launch failed - cleaning up connection
```
The same happens with the prefix.

@reviewbybees 