### PR TITLE
Hide empty port warninig

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1475,10 +1475,14 @@ public class SSHLauncher extends ComputerLauncher {
             if (!(context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance()).hasPermission(Computer.CONFIGURE)) {
                 return new ListBoxModel();
             }
-            int portValue = Integer.parseInt(port);
-            return new StandardUsernameListBoxModel().withMatching(SSHAuthenticator.matcher(Connection.class),
-                    CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, context,
-                            ACL.SYSTEM, SSHLauncher.SSH_SCHEME, new HostnamePortRequirement(host, portValue)));
+            try {
+                int portValue = Integer.parseInt(port);
+                return new StandardUsernameListBoxModel().withMatching(SSHAuthenticator.matcher(Connection.class),
+                        CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, context,
+                                ACL.SYSTEM, SSHLauncher.SSH_SCHEME, new HostnamePortRequirement(host, portValue)));
+            } catch (NumberFormatException ex) {
+                return new ListBoxModel();
+            }
         }
     }
 

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -30,37 +30,57 @@ import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.util.Collections;
 
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.DomainSpecification;
+import com.cloudbees.plugins.credentials.domains.HostnamePortRequirement;
+import com.cloudbees.plugins.credentials.domains.HostnamePortSpecification;
+import hudson.model.Descriptor;
 import hudson.model.Node.Mode;
 import hudson.model.Slave;
 import hudson.plugins.sshslaves.SSHLauncher.DefaultJDKInstaller;
+import hudson.security.ACL;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.RetentionStrategy;
-import junit.framework.TestCase;
 
-import org.junit.Assert;
+import hudson.util.ListBoxModel;
+import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class SSHLauncherTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SSHLauncherTest {
+
+	@Rule
+	public JenkinsRule j = new JenkinsRule();
 
 	@Test
 	public void testCheckJavaVersionOpenJDK7NetBSD() throws Exception {
-		Assert.assertTrue("OpenJDK7 on NetBSD should be supported", checkSupported("openjdk-7-netbsd.version"));
+		assertTrue("OpenJDK7 on NetBSD should be supported", checkSupported("openjdk-7-netbsd.version"));
 	}
 
 	@Test
 	public void testCheckJavaVersionOpenJDK6Linux() throws Exception {
-		Assert.assertTrue("OpenJDK6 on Linux should be supported", checkSupported("openjdk-6-linux.version"));
+		assertTrue("OpenJDK6 on Linux should be supported", checkSupported("openjdk-6-linux.version"));
 	}
 
 	@Test
 	public void testCheckJavaVersionSun6Linux() throws Exception {
-		Assert.assertTrue("Sun 6 on Linux should be supported", checkSupported("sun-java-1.6-linux.version"));
+		assertTrue("Sun 6 on Linux should be supported", checkSupported("sun-java-1.6-linux.version"));
 	}
 
 	@Test
 	public void testCheckJavaVersionSun6Mac() throws Exception {
-		Assert.assertTrue("Sun 6 on Mac should be supported", checkSupported("sun-java-1.6-mac.version"));
+		assertTrue("Sun 6 on Mac should be supported", checkSupported("sun-java-1.6-mac.version"));
 	}
 
 	@Test
@@ -79,7 +99,6 @@ public class SSHLauncherTest extends HudsonTestCase {
 	 * @param testVersionOutput
 	 *            the resource to find relative to this class that contains the
 	 *            output of "java -version"
-	 * @return
 	 */
 	private static boolean checkSupported(final String testVersionOutput) throws IOException {
         final String javaCommand = "testing-java";
@@ -93,18 +112,19 @@ public class SSHLauncherTest extends HudsonTestCase {
         return null != result;
 	}
 
+	@Test
     public void testConfigurationRoundtrip() throws Exception {
         SSHLauncher launcher = new SSHLauncher("localhost", 123, null, "pass", "xyz", new DefaultJDKInstaller(), null, null, null, 0, 0);
         DumbSlave slave = new DumbSlave("slave", "dummy",
-                createTmpDir().getPath(), "1", Mode.NORMAL, "",
+                j.createTmpDir().getPath(), "1", Mode.NORMAL, "",
                 launcher, RetentionStrategy.NOOP, Collections.EMPTY_LIST);
-        hudson.addNode(slave);
+        j.jenkins.addNode(slave);
 
-        submit(createWebClient().getPage(slave,"configure").getFormByName("config"));
-        Slave n = (Slave)hudson.getNode("slave");
+        j.submit(j.createWebClient().getPage(slave,"configure").getFormByName("config"));
+        Slave n = (Slave) j.jenkins.getNode("slave");
 
         assertNotSame(n,slave);
         assertNotSame(n.getLauncher(),launcher);
-        assertEqualDataBoundBeans(n.getLauncher(),launcher);
+        j.assertEqualDataBoundBeans(n.getLauncher(),launcher);
     }
 }

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -127,4 +127,22 @@ public class SSHLauncherTest {
         assertNotSame(n.getLauncher(),launcher);
         j.assertEqualDataBoundBeans(n.getLauncher(),launcher);
     }
+
+
+	@Test
+	public void fillCredentials() {
+		SystemCredentialsProvider.getInstance().getDomainCredentialsMap().put(
+				new Domain("test", null, Collections.<DomainSpecification>singletonList(
+						new HostnamePortSpecification(null, null)
+				)),
+				Collections.<Credentials>singletonList(
+						new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, "dummyCredentialId", "john", null, null, null)
+				)
+		);
+
+		SSHLauncher.DescriptorImpl desc = (SSHLauncher.DescriptorImpl) j.jenkins.getDescriptorOrDie(SSHLauncher.class);
+		assertEquals(1, desc.doFillCredentialsIdItems(j.jenkins, "", "22").size());
+		assertEquals(0, desc.doFillCredentialsIdItems(j.jenkins, "", "forty two").size());
+		assertEquals(0, desc.doFillCredentialsIdItems(j.jenkins, "", "").size());
+	}
 }


### PR DESCRIPTION
When the port is not specified, following warning is printed.

[whitespace aware diff](https://github.com/jenkinsci/ssh-slaves-plugin/pull/30/files?w=1)

```
master57956|WARNING: Error while serving http://127.0.0.1:57956/descriptorByName/hudson.plugins.sshslaves.SSHLauncher/fillCredentialsIdItems
master57956|java.lang.reflect.InvocationTargetException
master57956|	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
master57956|	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
master57956|	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
master57956|	at java.lang.reflect.Method.invoke(Method.java:606)
master57956|	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:298)
master57956|	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:161)
master57956|	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:96)
master57956|	at org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:121)
master57956|	at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
master57956|	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:746)
master57956|	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:876)
master57956|	at org.kohsuke.stapler.MetaClass$6.doDispatch(MetaClass.java:249)
master57956|	at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
master57956|	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:746)
master57956|	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:876)
master57956|	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:649)
master57956|	at org.kohsuke.stapler.Stapler.service(Stapler.java:238)
master57956|	at javax.servlet.http.HttpServlet.service(HttpServlet.java:848)
master57956|	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:686)
master57956|	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1494)
master57956|	at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:132)
master57956|	at hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:123)
master57956|	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1482)
master57956|	at hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:49)
master57956|	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1482)
master57956|	at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:84)
master57956|	at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:76)
master57956|	at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:171)
master57956|	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1482)
master57956|	at org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:49)
master57956|	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1482)
master57956|	at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:81)
master57956|	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1482)
master57956|	at org.kohsuke.stapler.DiagnosticThreadNameFilter.doFilter(DiagnosticThreadNameFilter.java:30)
master57956|	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1474)
master57956|	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:499)
master57956|	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:137)
master57956|	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:533)
master57956|	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:231)
master57956|	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1086)
master57956|	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:428)
master57956|	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:193)
master57956|	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1020)
master57956|	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:135)
master57956|	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
master57956|	at org.eclipse.jetty.server.Server.handle(Server.java:370)
master57956|	at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:489)
master57956|	at org.eclipse.jetty.server.AbstractHttpConnection.content(AbstractHttpConnection.java:960)
master57956|	at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.content(AbstractHttpConnection.java:1021)
master57956|	at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:865)
master57956|	at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:240)
master57956|	at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:82)
master57956|	at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:668)
master57956|	at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:52)
master57956|	at winstone.BoundedExecutorService$1.run(BoundedExecutorService.java:77)
master57956|	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
master57956|	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
master57956|	at java.lang.Thread.run(Thread.java:745)
master57956|Caused by: java.lang.NumberFormatException: For input string: ""
master57956|	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
master57956|	at java.lang.Integer.parseInt(Integer.java:504)
master57956|	at java.lang.Integer.parseInt(Integer.java:527)
master57956|	at hudson.plugins.sshslaves.SSHLauncher$DescriptorImpl.doFillCredentialsIdItems(SSHLauncher.java:1415)
master57956|	... 58 more
```