### PR TITLE
[JENKINS-33720] Upgrade to plugin pom 2.4 and bump baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 .project
 .settings
 work
+bin

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532</version>
+    <version>2.4</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>
@@ -17,6 +17,8 @@
   <properties>
     <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
+    <jenkins.version>1.580.1</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <developers>
@@ -67,26 +69,6 @@
       <artifactId>ssh-credentials</artifactId>
       <version>1.6.1</version>
     </dependency>
-    <!-- jenkins dependencies -->
-    <!-- test dependencies -->
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>${project.version}</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -94,43 +76,13 @@
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>1.106</version>
         <configuration>
           <systemProperties>
             <hudson.bundled.plugins>${basedir}/work/plugins/ssh-slaves.hpl</hudson.bundled.plugins>
           </systemProperties>
-          <compatibleSinceVersion>1.0</compatibleSinceVersion>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.8</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${findbugs-maven-plugin.version}</version>
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-          <failOnError>${findbugs.failOnError}</failOnError>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-findbugs</id>
-            <phase>verify</phase> 
-            <goals>
-              <goal>check</goal> 
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
+     </plugins>
   </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -71,18 +71,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <configuration>
-          <systemProperties>
-            <hudson.bundled.plugins>${basedir}/work/plugins/ssh-slaves.hpl</hudson.bundled.plugins>
-          </systemProperties>
-        </configuration>
-      </plugin>
-     </plugins>
-  </build>
-
 </project>

--- a/src/main/java/hudson/plugins/sshslaves/PluginImpl.java
+++ b/src/main/java/hudson/plugins/sshslaves/PluginImpl.java
@@ -35,7 +35,6 @@ import hudson.Plugin;
  * Entry point of ssh-slaves plugin.
  *
  * @author Stephen Connolly
- * @plugin
  */
 public class PluginImpl extends Plugin {
 

--- a/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
@@ -280,7 +280,7 @@ public class SSHConnector extends ComputerConnector {
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context) {
             AccessControlled _context = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance());
-            if (_context != null && !_context.hasPermission(Computer.CONFIGURE)) {
+            if (_context == null || !_context.hasPermission(Computer.CONFIGURE)) {
                 return new ListBoxModel();
             }
             return new StandardUsernameListBoxModel().withMatching(SSHAuthenticator.matcher(Connection.class),

--- a/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
@@ -51,8 +51,8 @@ import hudson.security.AccessControlled;
 
 /**
  * {@link ComputerConnector} for {@link SSHLauncher}.
- * <p/>
- * <p/>
+ * <p>
+ * <p>
  * Significant code duplication between this and {@link SSHLauncher} because of the historical reason.
  * Newer plugins like this should define a separate Describable connection parameter class and have
  * connector and launcher share them.
@@ -172,7 +172,7 @@ public class SSHConnector extends ComputerConnector {
     }
 
     /**
-     * @see SSHLauncher#(String, int, StandardUsernameCredentials, String, String, String, String, String, Integer, Integer, Integer)
+     * @see SSHLauncher#SSHLauncher(String, int, String, String, String, String, String, Integer, Integer, Integer)
      */
     @DataBoundConstructor
     public SSHConnector(int port, String credentialsId, String jvmOptions, String javaPath,
@@ -183,7 +183,7 @@ public class SSHConnector extends ComputerConnector {
     }
 
     /**
-     * @see SSHLauncher#(String, int, StandardUsernameCredentials, String, String, String, String, String, Integer)
+     * @see SSHLauncher#SSHLauncher(String, int, String, String, String, String, String, Integer)
      */
     @Deprecated
     public SSHConnector(int port, String credentialsId, String jvmOptions, String javaPath,
@@ -193,7 +193,7 @@ public class SSHConnector extends ComputerConnector {
     }
 
     /**
-     * @deprecated Use {@link #(int,String,String,String,String,String,Integer)}
+     * @deprecated Use {@link SSHConnector#SSHConnector(int,String,String,String,String,String,Integer)}
      */
     @Deprecated
     public SSHConnector(int port, String credentialsId, String jvmOptions, String javaPath,
@@ -279,7 +279,8 @@ public class SSHConnector extends ComputerConnector {
         }
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context) {
-            if (!(context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance()).hasPermission(Computer.CONFIGURE)) {
+            AccessControlled _context = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance());
+            if (_context != null && !_context.hasPermission(Computer.CONFIGURE)) {
                 return new ListBoxModel();
             }
             return new StandardUsernameListBoxModel().withMatching(SSHAuthenticator.matcher(Connection.class),

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1473,7 +1473,7 @@ public class SSHLauncher extends ComputerLauncher {
                                                      @QueryParameter String host,
                                                      @QueryParameter String port) {
             AccessControlled _context = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance());
-            if (_context != null && !_context.hasPermission(Computer.CONFIGURE)) {
+            if (_context == null || !_context.hasPermission(Computer.CONFIGURE)) {
                 return new ListBoxModel();
             }
             int portValue = Integer.parseInt(port);

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -283,7 +283,7 @@ public class SSHLauncher extends ComputerLauncher {
     }
 
     /**
-     * @deprecated use {@link SSHLauncher#(String,int,String,String,String,String,String,Integer)}
+     * @deprecated use {@link  SSHLauncher#SSHLauncher(String,int,String,String,String,String,String,Integer)}
      */
     @Deprecated
     public SSHLauncher(String host, int port, String credentialsId,
@@ -1472,7 +1472,8 @@ public class SSHLauncher extends ComputerLauncher {
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context,
                                                      @QueryParameter String host,
                                                      @QueryParameter String port) {
-            if (!(context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance()).hasPermission(Computer.CONFIGURE)) {
+            AccessControlled _context = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance());
+            if (_context != null && !_context.hasPermission(Computer.CONFIGURE)) {
                 return new ListBoxModel();
             }
             int portValue = Integer.parseInt(port);

--- a/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="${%Credentials}" field="credentialsId">

--- a/src/main/resources/hudson/plugins/sshslaves/SSHLauncher/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHLauncher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Host}" field="host">


### PR DESCRIPTION
Included in this PR:

- [x] Upgrade to plugin parent pom 2.4
- [x] Bump baseline to 1.580.1. With 1.532, project failed to build (with Java8) due to a bug in XStream [that was fixed in XStream 1.4.6](http://x-stream.github.io/jira/746/). 1.532 includes version 1.4.4 of XStream while 1.580.1 includes 1.4.7.
- [x] Fix FindBugs errors after upgrade
- [x] Fix Javadoc errors after upgrade
- [x] Fix injected tests errors after upgrade

PCT runs successfully after the upgrade. 

@reviewbybees esp. @stephenc 