### PR TITLE
[JENKINS-42022] Remove 'unix machines' from plugin's description.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <name>Jenkins SSH Slaves plugin</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/SSH+Slaves+plugin</url>
-  <description>Allows to launch agents running on Unix machines over SSH, using a Java implementation of the SSH protocol</description>
+  <description>Allows to launch agents over SSH, using a Java implementation of the SSH protocol</description>
 
   <properties>
     <jenkins.version>1.609.1</jenkins.version>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  Allows to launch agents running on Unix machines over SSH, using a Java implementation of the SSH protocol.
+  Allows to launch agents over SSH, using a Java implementation of the SSH protocol.
 </div>


### PR DESCRIPTION
[JENKINS-42022](https://issues.jenkins-ci.org/browse/JENKINS-42022)

Adapt descriptions in POM and index.jelly files after  [PR #33](https://github.com/jenkinsci/ssh-slaves-plugin/pull/33)

@reviewbybees @stephenc @olamy 