### PR TITLE
[JENKINS-43481] Bump JDKVERSION to jdk8-u121

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -144,7 +144,7 @@ public class SSHLauncher extends ComputerLauncher {
     public static final SchemeRequirement SSH_SCHEME = new SchemeRequirement("ssh");
 
 
-    public static final String JDKVERSION = "jdk-7u80";
+    public static final String JDKVERSION = "jdk-8u181";
     public static final String DEFAULT_JDK = JDKVERSION + "-oth-JPR";
 
     // Some of the messages observed in the wild:

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -144,7 +144,7 @@ public class SSHLauncher extends ComputerLauncher {
     public static final SchemeRequirement SSH_SCHEME = new SchemeRequirement("ssh");
 
 
-    public static final String JDKVERSION = "jdk-8u181";
+    public static final String JDKVERSION = "jdk-8u121";
     public static final String DEFAULT_JDK = JDKVERSION + "-oth-JPR";
 
     // Some of the messages observed in the wild:


### PR DESCRIPTION
As jdk7 reached end of life, i would recommend to bump the version to a rather recent one.

We might discuss further, if we expose JDKVERSION via "Manage Jenkins".
Like "latest", "please type jdkversion here/choose from these jdks" and a "stable version".
The latter one would behave like a final JDKVERSION.