### PR TITLE
[FIXED JENKINS-42959] Specify preferred host keys during connect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
   <description>Allows to launch agents over SSH, using a Java implementation of the SSH protocol</description>
 
   <properties>
-    <jenkins.version>1.609.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.625</jenkins.version>
+    <java.level>7</java.level>
     <jenkins-test-harness.version>2.18</jenkins-test-harness.version>
   </properties>
 
@@ -62,6 +62,13 @@
 
   <dependencies>
     <!-- regular dependencies -->
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>trilead-ssh2</artifactId>
+      <version>build217-jenkins-9</version>
+      <scope>provided</scope>
+      <!-- we only need the newer version for testing, we use the bundled version during execution -->
+    </dependency>
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>trilead-ssh2</artifactId>
-      <version>build217-jenkins-9</version>
+      <version>build-217-jenkins-11</version>
       <scope>provided</scope>
       <!-- we only need the newer version for testing, we use the bundled version during execution -->
     </dependency>

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -786,6 +786,7 @@ public class SSHLauncher extends ComputerLauncher {
             public Boolean call() throws InterruptedException {
                 Boolean rval = Boolean.FALSE;
                 try {
+                    connection.setServerHostKeyAlgorithms(sshHostKeyVerificationStrategy.getPreferredKeyAlgorithms(computer));
 
                     openConnection(listener, computer);
 

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/JenkinsTrilead9VersionSupport.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/JenkinsTrilead9VersionSupport.java
@@ -1,0 +1,39 @@
+package hudson.plugins.sshslaves.verifiers;
+
+import com.trilead.ssh2.signature.KeyAlgorithm;
+import com.trilead.ssh2.signature.KeyAlgorithmManager;
+import hudson.plugins.sshslaves.Messages;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Michael Clarke
+ */
+class JenkinsTrilead9VersionSupport extends TrileadVersionSupportManager.TrileadVersionSupport {
+
+    @Override
+    public String[] getSupportedAlgorithms() {
+        List<String> algorithms = new ArrayList<>();
+        for (KeyAlgorithm<?, ?> algorithm : KeyAlgorithmManager.getSupportedAlgorithms()) {
+            algorithms.add(algorithm.getKeyFormat());
+        }
+        return algorithms.toArray(new String[algorithms.size()]);
+    }
+
+    @Override
+    public HostKey parseKey(String algorithm, byte[] keyValue) {
+        for (KeyAlgorithm<?, ?> keyAlgorithm : KeyAlgorithmManager.getSupportedAlgorithms()) {
+            try {
+                if (keyAlgorithm.getKeyFormat().equals(algorithm)) {
+                    keyAlgorithm.decodePublicKey(keyValue);
+                    return new HostKey(algorithm, keyValue);
+                }
+            } catch (IOException ex) {
+                throw new IllegalArgumentException(Messages.ManualKeyProvidedHostKeyVerifier_KeyValueDoesNotParse(algorithm), ex);
+            }
+        }
+        throw new IllegalArgumentException("Unexpected key algorithm " + algorithm);
+    }
+}

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/JenkinsTrilead9VersionSupport.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/JenkinsTrilead9VersionSupport.java
@@ -3,6 +3,8 @@ package hudson.plugins.sshslaves.verifiers;
 import com.trilead.ssh2.signature.KeyAlgorithm;
 import com.trilead.ssh2.signature.KeyAlgorithmManager;
 import hudson.plugins.sshslaves.Messages;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -11,6 +13,7 @@ import java.util.List;
 /**
  * @author Michael Clarke
  */
+@Restricted(NoExternalUse.class)
 class JenkinsTrilead9VersionSupport extends TrileadVersionSupportManager.TrileadVersionSupport {
 
     @Override

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/JenkinsTrilead9VersionSupport.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/JenkinsTrilead9VersionSupport.java
@@ -23,7 +23,7 @@ class JenkinsTrilead9VersionSupport extends TrileadVersionSupportManager.Trilead
     }
 
     @Override
-    public HostKey parseKey(String algorithm, byte[] keyValue) {
+    public HostKey parseKey(String algorithm, byte[] keyValue) throws KeyParseException {
         for (KeyAlgorithm<?, ?> keyAlgorithm : KeyAlgorithmManager.getSupportedAlgorithms()) {
             try {
                 if (keyAlgorithm.getKeyFormat().equals(algorithm)) {
@@ -31,9 +31,9 @@ class JenkinsTrilead9VersionSupport extends TrileadVersionSupportManager.Trilead
                     return new HostKey(algorithm, keyValue);
                 }
             } catch (IOException ex) {
-                throw new IllegalArgumentException(Messages.ManualKeyProvidedHostKeyVerifier_KeyValueDoesNotParse(algorithm), ex);
+                throw new KeyParseException(Messages.ManualKeyProvidedHostKeyVerifier_KeyValueDoesNotParse(algorithm), ex);
             }
         }
-        throw new IllegalArgumentException("Unexpected key algorithm " + algorithm);
+        throw new KeyParseException("Unexpected key algorithm: " + algorithm);
     }
 }

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/KeyParseException.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/KeyParseException.java
@@ -1,0 +1,16 @@
+package hudson.plugins.sshslaves.verifiers;
+
+/**
+ * @author Michael Clarke
+ * @since 1.18
+ */
+public class KeyParseException extends Exception {
+
+    public KeyParseException(String message) {
+        super(message);
+    }
+
+    public KeyParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy.java
@@ -24,6 +24,7 @@
 package hudson.plugins.sshslaves.verifiers;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -72,6 +73,16 @@ public class KnownHostsFileKeyVerificationStrategy extends SshHostKeyVerificatio
             return false;
         }
         
+    }
+
+    @Override
+    public String[] getPreferredKeyAlgorithms(SlaveComputer computer) throws IOException {
+        if (!KNOWN_HOSTS_FILE.exists()) {
+            return super.getPreferredKeyAlgorithms(computer);
+        }
+
+        KnownHosts knownHosts = new KnownHosts(KNOWN_HOSTS_FILE);
+        return knownHosts.getPreferredServerHostkeyAlgorithmOrder(((SSHLauncher) computer.getLauncher()).getHost());
     }
     
     @Extension

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy.java
@@ -82,13 +82,16 @@ public class KnownHostsFileKeyVerificationStrategy extends SshHostKeyVerificatio
 
     @Override
     public String[] getPreferredKeyAlgorithms(SlaveComputer computer) throws IOException {
-        if (!KNOWN_HOSTS_FILE.exists()) {
+        ComputerLauncher launcher = computer.getLauncher();
+
+        if (!(launcher instanceof SSHLauncher) || !KNOWN_HOSTS_FILE.exists()) {
             return super.getPreferredKeyAlgorithms(computer);
         }
 
         KnownHosts knownHosts = new KnownHosts(KNOWN_HOSTS_FILE);
-        return knownHosts.getPreferredServerHostkeyAlgorithmOrder(((SSHLauncher) computer.getLauncher()).getHost());
+        return knownHosts.getPreferredServerHostkeyAlgorithmOrder(((SSHLauncher) launcher).getHost());
     }
+
     
     @Extension
     public static class KnownHostsFileKeyVerificationStrategyDescriptor extends SshHostKeyVerificationStrategyDescriptor {

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy.java
@@ -26,6 +26,7 @@ package hudson.plugins.sshslaves.verifiers;
 import java.io.File;
 import java.io.IOException;
 
+import hudson.slaves.ComputerLauncher;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.trilead.ssh2.KnownHosts;
@@ -53,6 +54,10 @@ public class KnownHostsFileKeyVerificationStrategy extends SshHostKeyVerificatio
     
     @Override
     public boolean verify(SlaveComputer computer, HostKey hostKey, TaskListener listener) throws Exception {
+        ComputerLauncher launcher = computer.getLauncher();
+        if (!(launcher instanceof SSHLauncher)) {
+            return false;
+        }
 
         if (!KNOWN_HOSTS_FILE.exists()) {
             listener.getLogger().println(Messages.KnownHostsFileHostKeyVerifier_NoKnownHostsFile(KNOWN_HOSTS_FILE.getAbsolutePath()));
@@ -60,7 +65,7 @@ public class KnownHostsFileKeyVerificationStrategy extends SshHostKeyVerificatio
         }
         
         KnownHosts knownHosts = new KnownHosts(KNOWN_HOSTS_FILE);
-        int result = knownHosts.verifyHostkey(((SSHLauncher)computer.getLauncher()).getHost(), hostKey.getAlgorithm(), hostKey.getKey());
+        int result = knownHosts.verifyHostkey(((SSHLauncher)launcher).getHost(), hostKey.getAlgorithm(), hostKey.getKey());
         
         if (KnownHosts.HOSTKEY_IS_OK == result) {
             listener.getLogger().println(Messages.KnownHostsFileHostKeyVerifier_KeyTrused(SSHLauncher.getTimestamp()));

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/ManuallyTrustedKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/ManuallyTrustedKeyVerificationStrategy.java
@@ -33,6 +33,8 @@ import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.SlaveComputer;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -96,6 +98,24 @@ public class ManuallyTrustedKeyVerificationStrategy extends SshHostKeyVerificati
             listener.getLogger().println(Messages.ManualTrustingHostKeyVerifier_KeyTrused(SSHLauncher.getTimestamp()));
             return true;
         }
+    }
+
+    @Override
+    public String[] getPreferredKeyAlgorithms(SlaveComputer computer) throws IOException {
+        String[] algorithms = super.getPreferredKeyAlgorithms(computer);
+
+        HostKey hostKey = HostKeyHelper.getInstance().getHostKey(computer);
+
+        if (null != hostKey) {
+            List<String> sortedAlgorithms = new ArrayList<>(Arrays.asList(algorithms));
+
+            sortedAlgorithms.remove(hostKey.getAlgorithm());
+            sortedAlgorithms.add(0, hostKey.getAlgorithm());
+
+            algorithms = sortedAlgorithms.toArray(new String[sortedAlgorithms.size()]);
+        }
+
+        return algorithms;
     }
 
     /** TODO replace with {@link Computer#addAction} after core baseline picks up JENKINS-42969 fix */

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/SshHostKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/SshHostKeyVerificationStrategy.java
@@ -29,6 +29,8 @@ import hudson.model.TaskListener;
 import hudson.slaves.SlaveComputer;
 import jenkins.model.Jenkins;
 
+import java.io.IOException;
+
 /**
  * A method for verifying the host key provided by the remote host during the
  * initiation of each connection.
@@ -53,6 +55,10 @@ public abstract class SshHostKeyVerificationStrategy implements Describable<SshH
      * @since 1.12
      */
     public abstract boolean verify(SlaveComputer computer, HostKey hostKey, TaskListener listener) throws Exception;
+
+    public String[] getPreferredKeyAlgorithms(SlaveComputer computer) throws IOException {
+        return TrileadVersionSupportManager.getTrileadSupport().getSupportedAlgorithms();
+    }
     
     public static abstract class SshHostKeyVerificationStrategyDescriptor extends Descriptor<SshHostKeyVerificationStrategy> {
         

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
@@ -3,6 +3,8 @@ package hudson.plugins.sshslaves.verifiers;
 import com.trilead.ssh2.signature.DSASHA1Verify;
 import com.trilead.ssh2.signature.RSASHA1Verify;
 import hudson.plugins.sshslaves.Messages;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
 
@@ -10,6 +12,7 @@ import java.io.IOException;
  * @author Michael Clarke
  * @since 1.18
  */
+@Restricted(NoExternalUse.class)
 final class TrileadVersionSupportManager {
 
     static TrileadVersionSupport getTrileadSupport() {
@@ -33,6 +36,7 @@ final class TrileadVersionSupportManager {
 
     public abstract static class TrileadVersionSupport {
 
+        @Restricted(NoExternalUse.class)
         /*package*/ TrileadVersionSupport() {
             super();
         }

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
@@ -7,6 +7,8 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author Michael Clarke
@@ -15,22 +17,32 @@ import java.io.IOException;
 @Restricted(NoExternalUse.class)
 final class TrileadVersionSupportManager {
 
+    private static final Logger LOGGER = Logger.getLogger(TrileadVersionSupportManager.class.getName());
+
     static TrileadVersionSupport getTrileadSupport() {
         try {
-            Thread.currentThread().getContextClassLoader().loadClass("com.trilead.ssh2.signature.KeyAlgorithmManager");
-            return createVersion9Instance();
-        } catch (ReflectiveOperationException e) {
-            // KeyAlgorithmManager doesn't exist, fall back to legacy trilead handler
-            return new LegacyTrileadVersionSupport();
+            if (isAfterTrilead8()) {
+                return createVersion9Instance();
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not create Trilead support class. Using legacy Trilead features", e);
         }
+        // We're on an old version of Triilead or couldn't create a new handler, fall back to legacy trilead handler
+        return new LegacyTrileadVersionSupport();
     }
 
-    private static TrileadVersionSupport createVersion9Instance() {
+    private static boolean isAfterTrilead8() {
         try {
-            return (TrileadVersionSupport) Thread.currentThread().getContextClassLoader().loadClass("hudson.plugins.sshslaves.verifiers.JenkinsTrilead9VersionSupport").newInstance();
-        } catch (ReflectiveOperationException e) {
-            throw new IllegalArgumentException("Could not create Trilead support class", e);
+            Thread.currentThread().getContextClassLoader().loadClass("com.trilead.ssh2.signature.KeyAlgorithmManager");
+        } catch (ClassNotFoundException ex) {
+            return false;
         }
+        return true;
+    }
+
+    private static TrileadVersionSupport createVersion9Instance() throws ReflectiveOperationException {
+        return (TrileadVersionSupport) Thread.currentThread().getContextClassLoader()
+                .loadClass("hudson.plugins.sshslaves.verifiers.JenkinsTrilead9VersionSupport").newInstance();
 
     }
 

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
@@ -1,0 +1,70 @@
+package hudson.plugins.sshslaves.verifiers;
+
+import com.trilead.ssh2.signature.DSASHA1Verify;
+import com.trilead.ssh2.signature.RSASHA1Verify;
+import hudson.plugins.sshslaves.Messages;
+
+import java.io.IOException;
+
+/**
+ * @author Michael Clarke
+ * @since 1.18
+ */
+final class TrileadVersionSupportManager {
+
+    static TrileadVersionSupport getTrileadSupport() {
+        try {
+            Thread.currentThread().getContextClassLoader().loadClass("com.trilead.ssh2.signature.KeyAlgorithmManager");
+            return createaVersion9Instance();
+        } catch (ReflectiveOperationException e) {
+            // KeyAlgorithmManager doesn't exist, fall back to legacy trilead handler
+            return new LegacyTrileadVersionSupport();
+        }
+    }
+
+    private static TrileadVersionSupport createaVersion9Instance() {
+        try {
+            return (TrileadVersionSupport) Class.forName("hudson.plugins.sshslaves.verifiers.JenkinsTrilead9VersionSupport").newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException("Could not create Trilead support class", e);
+        }
+
+    }
+
+    public abstract static class TrileadVersionSupport {
+
+        /*package*/ TrileadVersionSupport() {
+            super();
+        }
+
+        public abstract String[] getSupportedAlgorithms();
+
+        public abstract HostKey parseKey(String algorithm, byte[] keyValue);
+    }
+
+    private static class LegacyTrileadVersionSupport extends TrileadVersionSupport {
+
+        @Override
+        public String[] getSupportedAlgorithms() {
+            return new String[]{"ssh-rsa", "ssh-dss"};
+        }
+
+        @Override
+        public HostKey parseKey(String algorithm, byte[] keyValue) {
+            try {
+                if ("ssh-rsa".equals(algorithm)) {
+                    RSASHA1Verify.decodeSSHRSAPublicKey(keyValue);
+                } else if ("ssh-dss".equals(algorithm)) {
+                    DSASHA1Verify.decodeSSHDSAPublicKey(keyValue);
+                } else {
+                    throw new IllegalArgumentException("Key algorithm should be one of ssh-rsa or ssh-dss");
+                }
+            } catch (IOException | StringIndexOutOfBoundsException ex) {
+                throw new IllegalArgumentException(Messages.ManualKeyProvidedHostKeyVerifier_KeyValueDoesNotParse(algorithm), ex);
+            }
+
+            return new HostKey(algorithm, keyValue);
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
@@ -18,14 +18,14 @@ final class TrileadVersionSupportManager {
     static TrileadVersionSupport getTrileadSupport() {
         try {
             Thread.currentThread().getContextClassLoader().loadClass("com.trilead.ssh2.signature.KeyAlgorithmManager");
-            return createaVersion9Instance();
+            return createVersion9Instance();
         } catch (ReflectiveOperationException e) {
             // KeyAlgorithmManager doesn't exist, fall back to legacy trilead handler
             return new LegacyTrileadVersionSupport();
         }
     }
 
-    private static TrileadVersionSupport createaVersion9Instance() {
+    private static TrileadVersionSupport createVersion9Instance() {
         try {
             return (TrileadVersionSupport) Class.forName("hudson.plugins.sshslaves.verifiers.JenkinsTrilead9VersionSupport").newInstance();
         } catch (ReflectiveOperationException e) {

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
@@ -11,6 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * An abstraction layer to allow handling of feature changes (e.g. new key types) between different Trilead versions.
  * @author Michael Clarke
  * @since 1.18
  */
@@ -19,6 +20,12 @@ final class TrileadVersionSupportManager {
 
     private static final Logger LOGGER = Logger.getLogger(TrileadVersionSupportManager.class.getName());
 
+    /**
+     * Craetes an instance of TrileadVersionSupport that can provide functionality relevant to the version of Trilead
+     * available in the current executing instance of Jenkins.
+     * @return an instance of TrileadVersionSupport that provides functionality relevant for the version of Trilead
+     * currently on the classpath
+     */
     static TrileadVersionSupport getTrileadSupport() {
         try {
             if (isAfterTrilead8()) {
@@ -53,8 +60,19 @@ final class TrileadVersionSupportManager {
             super();
         }
 
+        /**
+         * Returns an array of all Key algorithms supported by Yrilead, e.g. ssh-rsa, ssh-dsa, ssh-eds25519
+         * @return an array containing all the key algorithms the version of Trilead in use can support.
+         */
         public abstract String[] getSupportedAlgorithms();
 
+        /**
+         * Parses a raw key into a {@link HostKey} for later storage or comparison.
+         * @param algorithm the algorithm the key has been generated with, e.h. ssh-rsa, ssh-dss, ssh-ed25519
+         * @param keyValue the value of the key, typically encoded in PEM format.
+         * @return the input key in a format that can be compared to other keys
+         * @throws KeyParseException on any failure parsing the key, such as an unknown algorithm or invalid keyValue
+         */
         public abstract HostKey parseKey(String algorithm, byte[] keyValue) throws KeyParseException;
     }
 

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
@@ -39,7 +39,7 @@ final class TrileadVersionSupportManager {
 
         public abstract String[] getSupportedAlgorithms();
 
-        public abstract HostKey parseKey(String algorithm, byte[] keyValue);
+        public abstract HostKey parseKey(String algorithm, byte[] keyValue) throws KeyParseException;
     }
 
     private static class LegacyTrileadVersionSupport extends TrileadVersionSupport {
@@ -50,17 +50,17 @@ final class TrileadVersionSupportManager {
         }
 
         @Override
-        public HostKey parseKey(String algorithm, byte[] keyValue) {
+        public HostKey parseKey(String algorithm, byte[] keyValue) throws KeyParseException {
             try {
                 if ("ssh-rsa".equals(algorithm)) {
                     RSASHA1Verify.decodeSSHRSAPublicKey(keyValue);
                 } else if ("ssh-dss".equals(algorithm)) {
                     DSASHA1Verify.decodeSSHDSAPublicKey(keyValue);
                 } else {
-                    throw new IllegalArgumentException("Key algorithm should be one of ssh-rsa or ssh-dss");
+                    throw new KeyParseException("Key algorithm should be one of ssh-rsa or ssh-dss");
                 }
             } catch (IOException | StringIndexOutOfBoundsException ex) {
-                throw new IllegalArgumentException(Messages.ManualKeyProvidedHostKeyVerifier_KeyValueDoesNotParse(algorithm), ex);
+                throw new KeyParseException(Messages.ManualKeyProvidedHostKeyVerifier_KeyValueDoesNotParse(algorithm), ex);
             }
 
             return new HostKey(algorithm, keyValue);

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
@@ -27,7 +27,7 @@ final class TrileadVersionSupportManager {
 
     private static TrileadVersionSupport createVersion9Instance() {
         try {
-            return (TrileadVersionSupport) Class.forName("hudson.plugins.sshslaves.verifiers.JenkinsTrilead9VersionSupport").newInstance();
+            return (TrileadVersionSupport) Thread.currentThread().getContextClassLoader().loadClass("hudson.plugins.sshslaves.verifiers.JenkinsTrilead9VersionSupport").newInstance();
         } catch (ReflectiveOperationException e) {
             throw new IllegalArgumentException("Could not create Trilead support class", e);
         }

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategyTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategyTest.java
@@ -1,0 +1,40 @@
+package hudson.plugins.sshslaves.verifiers;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * @author Michael Clarke
+ */
+public class ManuallyProvidedKeyVerificationStrategyTest {
+
+    @Test
+    public void testRsa() throws IOException {
+        ManuallyProvidedKeyVerificationStrategy testCase = new ManuallyProvidedKeyVerificationStrategy("ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAtqwn/v4+sYBD0e5UT59zGjQ+iBOJvKbqVX22vt4hFIVrbwmB+HKJGwOINe1gnc/syPGj/5c6yoOnjTdpI/xerip6RjVPRTQVh2nNjsbXIS5epi/39nnPFZ/0hE3ozOtQ1j9OS5bXVBD770ha1UFnCql4DfcWj+y1QVYvm53p2fID+an0HNunnZjq+r2UJgt138lkZN2K7S42U/apqOHStFGVPxF+gmK1fI021QI+QjxfKOoyGNCpbAaMM6jzikqCJOE8M7jpSZgHMO2x+wvjMK8p2uXAaZlYJeUlEqUVGa9jjkdEiTPabFJyrKORrTWX7Ahs6C4vCAgWmNZzOmOvnw== rsa-key-20170516");
+        assertArrayEquals(new String[]{"ssh-rsa", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp256", "ssh-dss"}, testCase.getPreferredKeyAlgorithms(null));
+    }
+
+    @Test
+    public void testEd25519() throws IOException {
+        ManuallyProvidedKeyVerificationStrategy testCase = new ManuallyProvidedKeyVerificationStrategy("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMQPcXch45Uak9iiHt1puffR6LHZxZsHU0iyeyUnf5qW ed25519-key-20170516");
+        assertArrayEquals(new String[]{"ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp256", "ssh-rsa", "ssh-dss"}, testCase.getPreferredKeyAlgorithms(null));
+    }
+
+
+    @Test
+    public void testEcdsa() throws IOException {
+        ManuallyProvidedKeyVerificationStrategy testCase = new ManuallyProvidedKeyVerificationStrategy("ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMQMVHTpplIuqEcOR8j7wzydDUzXF0Fl82WluEJphpo2JKbJ4DNaL3Zu6bfeDQGuH3hWtG1H0r4ntoDtN940GGA= ecdsa-key-20170516");
+        assertArrayEquals(new String[]{"ecdsa-sha2-nistp256", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "ssh-rsa", "ssh-dss"}, testCase.getPreferredKeyAlgorithms(null));
+    }
+
+    @Test
+    public void testDsa() throws IOException {
+        ManuallyProvidedKeyVerificationStrategy testCase = new ManuallyProvidedKeyVerificationStrategy("ssh-dss AAAAB3NzaC1kc3MAAAAhAOD3H2nbagBMaZ7XDnGUBO3vuqi3McIC9A+smJH9lsnzAAAAFQD3lLxlCXN8K4CeNCJdHeXEpeE7vwAAACBtZ3osIr0OtX6uKFumP6ybXGrfiy7otYqmSPwS+A2MywAAACEA34SUyAprA9HHPmRqZnJ6Acgq6KKRrh4SKTPUdJa8aBc= dsa-key-20170516");
+        assertArrayEquals(new String[]{"ssh-dss", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp256", "ssh-rsa"}, testCase.getPreferredKeyAlgorithms(null));
+    }
+
+}

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManagerTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManagerTest.java
@@ -1,0 +1,44 @@
+package hudson.plugins.sshslaves.verifiers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Michael Clarke
+ */
+public class TrileadVersionSupportManagerTest {
+
+    @Test
+    public void testLegacyInstance() {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(new BlockingClassloader(Thread.currentThread().getContextClassLoader()));
+            String name = TrileadVersionSupportManager.getTrileadSupport().getClass().getName();
+            assertEquals("hudson.plugins.sshslaves.verifiers.TrileadVersionSupportManager$LegacyTrileadVersionSupport", name);
+        } finally {
+            Thread.currentThread().setContextClassLoader(loader);
+        }
+    }
+
+    @Test
+    public void testCurrentInstance() {
+        assertEquals(JenkinsTrilead9VersionSupport.class, TrileadVersionSupportManager.getTrileadSupport().getClass());
+    }
+
+
+    private static class BlockingClassloader extends ClassLoader {
+
+        public BlockingClassloader(ClassLoader parent) {
+            super(parent);
+        }
+
+        public Class<?> loadClass(String className) throws ClassNotFoundException {
+            if ("com.trilead.ssh2.signature.KeyAlgorithmManager".equals(className)) {
+                throw new ClassNotFoundException(className);
+            }
+            return super.loadClass(className);
+        }
+
+    }
+}


### PR DESCRIPTION
The remaining fix for JENKINS-42959: adds support for additional host key algorithms where Jenkins contains a newer version of Trilead, and specify the preferred host key algorithm for connecting in-case Jenkins has an old key format saved as the known key.