### PR TITLE
[JENKINS-44832] IAE due to empty or null list of preferred key algorithms

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -793,7 +793,12 @@ public class SSHLauncher extends ComputerLauncher {
             public Boolean call() throws InterruptedException {
                 Boolean rval = Boolean.FALSE;
                 try {
-                    connection.setServerHostKeyAlgorithms(getSshHostKeyVerificationStrategyDefaulted().getPreferredKeyAlgorithms(computer));
+                    String[] preferredKeyAlgorithms = getSshHostKeyVerificationStrategyDefaulted().getPreferredKeyAlgorithms(computer);
+                    if (preferredKeyAlgorithms != null && preferredKeyAlgorithms.length > 0) { // JENKINS-44832
+                        connection.setServerHostKeyAlgorithms(preferredKeyAlgorithms);
+                    } else {
+                        listener.getLogger().println("Warning: no key algorithms provided; JENKINS-42959 disabled");
+                    }
 
                     openConnection(listener, computer);
 

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy.java
@@ -40,6 +40,7 @@ import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.remoting.Base64;
 import hudson.slaves.SlaveComputer;
 import hudson.util.FormValidation;
+import java.util.Collections;
 
 /**
  * Checks a key provided by a remote hosts matches a key specified as being required by the
@@ -83,7 +84,8 @@ public class ManuallyProvidedKeyVerificationStrategy extends SshHostKeyVerificat
 
     @Override
     public String[] getPreferredKeyAlgorithms(SlaveComputer computer) throws IOException {
-        List<String> sortedAlgorithms = new ArrayList<>(Arrays.asList(super.getPreferredKeyAlgorithms(computer)));
+        String[] unsortedAlgorithms = super.getPreferredKeyAlgorithms(computer);
+        List<String> sortedAlgorithms = new ArrayList<>(unsortedAlgorithms != null ? Arrays.asList(unsortedAlgorithms) : Collections.<String>emptyList());
 
         sortedAlgorithms.remove(key.getAlgorithm());
         sortedAlgorithms.add(0, key.getAlgorithm());

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/SshHostKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/SshHostKeyVerificationStrategy.java
@@ -23,6 +23,8 @@
  */
 package hudson.plugins.sshslaves.verifiers;
 
+import com.trilead.ssh2.Connection;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
@@ -56,6 +58,12 @@ public abstract class SshHostKeyVerificationStrategy implements Describable<SshH
      */
     public abstract boolean verify(SlaveComputer computer, HostKey hostKey, TaskListener listener) throws Exception;
 
+    /**
+     * Provides a list of preferred key algorithms for this strategy and computer.
+     * @return a list of algorithms; empty or null lists will be ignored
+     * @see Connection#setServerHostKeyAlgorithms
+     */
+    @CheckForNull
     public String[] getPreferredKeyAlgorithms(SlaveComputer computer) throws IOException {
         return TrileadVersionSupportManager.getTrileadSupport().getSupportedAlgorithms();
     }


### PR DESCRIPTION
[JENKINS-44832](https://issues.jenkins-ci.org/browse/JENKINS-44832)

Amends #54. Not known how to reproduce, so no regression test.

@reviewbybees