### PR TITLE
Make "Name or service not known" errors retryable

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -159,7 +159,7 @@ public class SSHLauncher extends ComputerLauncher {
     // "No route to host", "No route to host (Host unreachable)"
     // "Premature connection close"
     private static final List<String> RECOVERABLE_FAILURES = Arrays.asList(
-            "Connection refused", "Connection reset", "Connection timed out", "No route to host", "Premature connection close"
+            "Connection refused", "Connection reset", "Connection timed out", "No route to host", "Premature connection close", "Name or service not known"
     );
 
     /**


### PR DESCRIPTION
We use a dynamic DNS setup where EC2 nodes add their own DNS via userdata scripts, and entries are cleaned up on node termination.

This means that we can end up in a situation where one of our slaves DNS names can be removed and when the slave comes back online the master doesn't retry the connection.