### PR TITLE
[JENKINS-44893] Fix Trilead support class instantiation

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
@@ -31,7 +31,7 @@ final class TrileadVersionSupportManager {
             if (isAfterTrilead8()) {
                 return createVersion9Instance();
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             LOGGER.log(Level.WARNING, "Could not create Trilead support class. Using legacy Trilead features", e);
         }
         // We're on an old version of Triilead or couldn't create a new handler, fall back to legacy trilead handler

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManager.java
@@ -40,7 +40,7 @@ final class TrileadVersionSupportManager {
 
     private static boolean isAfterTrilead8() {
         try {
-            Thread.currentThread().getContextClassLoader().loadClass("com.trilead.ssh2.signature.KeyAlgorithmManager");
+            Class.forName("com.trilead.ssh2.signature.KeyAlgorithmManager");
         } catch (ClassNotFoundException ex) {
             return false;
         }
@@ -48,7 +48,7 @@ final class TrileadVersionSupportManager {
     }
 
     private static TrileadVersionSupport createVersion9Instance() throws ReflectiveOperationException {
-        return (TrileadVersionSupport) Thread.currentThread().getContextClassLoader()
+        return (TrileadVersionSupport) TrileadVersionSupportManager.class.getClassLoader()
                 .loadClass("hudson.plugins.sshslaves.verifiers.JenkinsTrilead9VersionSupport").newInstance();
 
     }

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManagerTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManagerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -31,6 +32,7 @@ public class TrileadVersionSupportManagerTest {
     }
 
     @Test
+    @Issue("JENKINS-44893")
     public void testLegacyInstanceWithLinkageError() {
         BlockingClassloader classloader = newBlockingClassloader();
         classloader.inspectPackage("com.trilead.ssh2.signature");
@@ -46,6 +48,7 @@ public class TrileadVersionSupportManagerTest {
     }
 
     @Test
+    @Issue("JENKINS-44893")
     public void testCurrentInstanceWithIsolatedClassLoader() {
         BlockingClassloader classloader = newBlockingClassloader();
         Object trileadSupport = invokeGetTrileadSupport(classloader);

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManagerTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManagerTest.java
@@ -31,6 +31,16 @@ public class TrileadVersionSupportManagerTest {
     }
 
     @Test
+    public void testLegacyInstanceWithLinkageError() {
+        BlockingClassloader classloader = newBlockingClassloader();
+        classloader.inspectPackage("com.trilead.ssh2.signature");
+        classloader.block("com.trilead.ssh2.signature.KeyAlgorithm");
+
+        Object trileadSupport = invokeGetTrileadSupport(classloader);
+        assertEquals("hudson.plugins.sshslaves.verifiers.TrileadVersionSupportManager$LegacyTrileadVersionSupport", trileadSupport.getClass().getName());
+    }
+
+    @Test
     public void testCurrentInstance() {
         assertEquals(JenkinsTrilead9VersionSupport.class, TrileadVersionSupportManager.getTrileadSupport().getClass());
     }

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManagerTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrileadVersionSupportManagerTest.java
@@ -1,24 +1,33 @@
 package hudson.plugins.sshslaves.verifiers;
 
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * @author Michael Clarke
+ * @author Zhenlei Huang
  */
 public class TrileadVersionSupportManagerTest {
 
     @Test
     public void testLegacyInstance() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        try {
-            Thread.currentThread().setContextClassLoader(new BlockingClassloader(Thread.currentThread().getContextClassLoader()));
-            String name = TrileadVersionSupportManager.getTrileadSupport().getClass().getName();
-            assertEquals("hudson.plugins.sshslaves.verifiers.TrileadVersionSupportManager$LegacyTrileadVersionSupport", name);
-        } finally {
-            Thread.currentThread().setContextClassLoader(loader);
-        }
+        BlockingClassloader classloader = newBlockingClassloader();
+        classloader.block("com.trilead.ssh2.signature.KeyAlgorithmManager");
+
+        Object trileadSupport = invokeGetTrileadSupport(classloader);
+        assertEquals("hudson.plugins.sshslaves.verifiers.TrileadVersionSupportManager$LegacyTrileadVersionSupport", trileadSupport.getClass().getName());
     }
 
     @Test
@@ -26,19 +35,100 @@ public class TrileadVersionSupportManagerTest {
         assertEquals(JenkinsTrilead9VersionSupport.class, TrileadVersionSupportManager.getTrileadSupport().getClass());
     }
 
+    @Test
+    public void testCurrentInstanceWithIsolatedClassLoader() {
+        BlockingClassloader classloader = newBlockingClassloader();
+        Object trileadSupport = invokeGetTrileadSupport(classloader);
 
-    private static class BlockingClassloader extends ClassLoader {
+        assertEquals("hudson.plugins.sshslaves.verifiers.JenkinsTrilead9VersionSupport", trileadSupport.getClass().getName());
+        assertNotEquals(JenkinsTrilead9VersionSupport.class, trileadSupport.getClass());
+    }
+
+    private static Object invokeGetTrileadSupport(ClassLoader classloader) {
+        try {
+            Class<?> clz = Class.forName("hudson.plugins.sshslaves.verifiers.TrileadVersionSupportManager", true, classloader);
+            Method method = clz.getDeclaredMethod("getTrileadSupport");
+            method.setAccessible(true);
+            return method.invoke(null);
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static BlockingClassloader newBlockingClassloader() {
+        BlockingClassloader classloader = new BlockingClassloader(TrileadVersionSupportManagerTest.class.getClassLoader());
+        classloader.inspectPackage("hudson.plugins.sshslaves");
+        return classloader;
+    }
+
+
+    private static class BlockingClassloader extends URLClassLoader {
+
+        private final ClassLoader parent;
+
+        private final Set<String> blockingClasses = new HashSet<>();
+
 
         public BlockingClassloader(ClassLoader parent) {
-            super(parent);
+            super(new URL[0], parent);
+            this.parent = parent;
         }
 
+        @Override
         public Class<?> loadClass(String className) throws ClassNotFoundException {
-            if ("com.trilead.ssh2.signature.KeyAlgorithmManager".equals(className)) {
+            if (blockingClasses.contains(className)) {
                 throw new ClassNotFoundException(className);
             }
+
+            // child first
+            try {
+                return super.findClass(className);
+            } catch (ClassNotFoundException ignore) {
+            }
+
             return super.loadClass(className);
         }
 
+        public void inspectClass(String clz) {
+            URL[] urls = getResourceURLs(parent, clz, true);
+            for (URL url : urls) {
+                super.addURL(url);
+            }
+        }
+
+        public void inspectPackage(String pkg) {
+            URL[] urls = getResourceURLs(parent, pkg, false);
+            for (URL url : urls) {
+                super.addURL(url);
+            }
+        }
+
+        public void block(String clazz) {
+            blockingClasses.add(clazz);
+        }
+
+        public void unBlock(String clazz) {
+            blockingClasses.remove(clazz);
+        }
+
+        private static URL[] getResourceURLs(ClassLoader classLoader, String inspect, boolean isClass) {
+            String res = inspect.replace('.', '/');
+            if (isClass) {
+                res = res.concat(".class");
+            }
+            List<URL> list = new ArrayList<>();
+            try {
+                Enumeration<URL> enumeration = classLoader.getResources(res);
+                while (enumeration.hasMoreElements()) {
+                    String url = enumeration.nextElement().toString();
+                    if (url.endsWith(res)) {
+                        url = url.substring(0, url.length() - res.length());
+                    }
+                    list.add(new URL(url));
+                }
+            } catch (IOException ignore) {
+            }
+            return list.toArray(new URL[0]);
+        }
     }
 }


### PR DESCRIPTION
Issue link: [https://issues.jenkins-ci.org/browse/JENKINS-44893](https://issues.jenkins-ci.org/browse/JENKINS-44893)

Since the JenkinsTrilead9VersionSupport is within the same classpath as TrileadVersionSupportManager, we can safely instantiate it without worrying class loading issues.