### PR TITLE
Added a licensing definition to the Maven project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,14 @@
   <url>https://wiki.jenkins-ci.org/display/JENKINS/SSH+Slaves+plugin</url>
   <description>Allows to launch agents over SSH, using a Java implementation of the SSH protocol</description>
 
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <properties>
     <jenkins.version>1.625</jenkins.version>
     <java.level>7</java.level>


### PR DESCRIPTION
In order to meet the [prerequisites](https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Prerequisites) of plugin hosting in the Jenkins Organization, I'm adding the licensing definition in the Maven project.

@kohsuke, @olamy, @mc1arke and @stephenc as maintainers, What do you think?
@oleg-nenashev as active contributor, What do you think?
@reviewbybees 