### PR TITLE
[JENKINS-19465] - Prevent hanging of launcher when we disconnect the agent before the full launch operation execution.

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1371,7 +1371,7 @@ public class SSHLauncher extends ComputerLauncher {
         tearDownConnection(slaveComputer, listener);
     }
 
-    private synchronized void tearDownConnection(@Nonnull SlaveComputer slaveComputer, @Nonnull TaskListener listener) {
+    private synchronized void tearDownConnection(@Nonnull SlaveComputer slaveComputer, final @Nonnull TaskListener listener) {
         if (connection != null) {
             boolean connectionLost = reportTransportLoss(connection, listener);
             if (session != null) {

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -849,13 +849,14 @@ public class SSHLauncher extends ComputerLauncher {
         try {
             long time = System.currentTimeMillis();
             List<Future<Boolean>> results;
-            if (launcherExecutorService == null) {
+            final ExecutorService srv = launcherExecutorService;
+            if (srv == null) {
                 throw new IllegalStateException("Launcher Executor Service should be always non-null here, because the task allocates and closes service on its own");
             }
             if (this.getLaunchTimeoutMillis() > 0) {
-                results = launcherExecutorService.invokeAll(callables, this.getLaunchTimeoutMillis(), TimeUnit.MILLISECONDS);
+                results = srv.invokeAll(callables, this.getLaunchTimeoutMillis(), TimeUnit.MILLISECONDS);
             } else {
-                results = launcherExecutorService.invokeAll(callables);
+                results = srv.invokeAll(callables);
             }
             long duration = System.currentTimeMillis() - time;
             Boolean res;

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -880,7 +880,7 @@ public class SSHLauncher extends ComputerLauncher {
         } finally {
             ExecutorService srv = launcherExecutorService;
             if (srv != null) {
-                srv.shutdown();
+                srv.shutdownNow();
                 launcherExecutorService = null;
             }
         }

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -135,6 +135,8 @@ import static hudson.Util.*;
 import hudson.model.Computer;
 import hudson.security.AccessControlled;
 import hudson.util.VersionNumber;
+
+import javax.annotation.Nonnull;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import static java.util.logging.Level.*;
@@ -1366,79 +1368,81 @@ public class SSHLauncher extends ComputerLauncher {
             srv.shutdown();
         }
 
-        synchronized (this) {
-            if (connection != null) {
-                boolean connectionLost = reportTransportLoss(connection, listener);
-                if (session != null) {
-                    // give the process 3 seconds to write out its dying message before we cut the loss
-                    // and give up on this process. if the slave process had JVM crash, OOME, or any other
-                    // critical problem, this will allow us to capture that.
-                    // exit code is also an useful info to figure out why the process has died.
-                    try {
-                        listener.getLogger().println(getSessionOutcomeMessage(session, connectionLost));
-                        session.getStdout().close();
-                        session.close();
-                    } catch (Throwable t) {
-                        t.printStackTrace(listener.error(Messages.SSHLauncher_ErrorWhileClosingConnection()));
-                    }
-                    session = null;
+        tearDownConnection(slaveComputer, listener);
+    }
+
+    private synchronized void tearDownConnection(@Nonnull SlaveComputer slaveComputer, @Nonnull TaskListener listener) {
+        if (connection != null) {
+            boolean connectionLost = reportTransportLoss(connection, listener);
+            if (session != null) {
+                // give the process 3 seconds to write out its dying message before we cut the loss
+                // and give up on this process. if the slave process had JVM crash, OOME, or any other
+                // critical problem, this will allow us to capture that.
+                // exit code is also an useful info to figure out why the process has died.
+                try {
+                    listener.getLogger().println(getSessionOutcomeMessage(session, connectionLost));
+                    session.getStdout().close();
+                    session.close();
+                } catch (Throwable t) {
+                    t.printStackTrace(listener.error(Messages.SSHLauncher_ErrorWhileClosingConnection()));
                 }
+                session = null;
+            }
 
-                Slave n = slaveComputer.getNode();
-                if (n != null && !connectionLost) {
-                    String workingDirectory = getWorkingDirectory(n);
-                    final String fileName = workingDirectory + "/slave.jar";
-                    Future<?> tidyUp = Computer.threadPoolForRemoting.submit(new Runnable() {
-                        public void run() {
-                            // this would fail if the connection is already lost, so we want to check that.
-                            // TODO: Connection class should expose whether it is still connected or not.
+            Slave n = slaveComputer.getNode();
+            if (n != null && !connectionLost) {
+                String workingDirectory = getWorkingDirectory(n);
+                final String fileName = workingDirectory + "/slave.jar";
+                Future<?> tidyUp = Computer.threadPoolForRemoting.submit(new Runnable() {
+                    public void run() {
+                        // this would fail if the connection is already lost, so we want to check that.
+                        // TODO: Connection class should expose whether it is still connected or not.
 
-                            SFTPv3Client sftpClient = null;
-                            try {
-                                sftpClient = new SFTPv3Client(connection);
-                                sftpClient.rm(fileName);
-                            } catch (Exception e) {
-                                if (sftpClient == null) {// system without SFTP
-                                    try {
-                                        connection.exec("rm " + fileName, listener.getLogger());
-                                    } catch (Error error) {
-                                        throw error;
-                                    } catch (Throwable x) {
-                                        x.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
-                                        // We ignore other Exception types
-                                    }
-                                } else {
-                                    e.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
+                        SFTPv3Client sftpClient = null;
+                        try {
+                            sftpClient = new SFTPv3Client(connection);
+                            sftpClient.rm(fileName);
+                        } catch (Exception e) {
+                            if (sftpClient == null) {// system without SFTP
+                                try {
+                                    connection.exec("rm " + fileName, listener.getLogger());
+                                } catch (Error error) {
+                                    throw error;
+                                } catch (Throwable x) {
+                                    x.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
+                                    // We ignore other Exception types
                                 }
-                            } finally {
-                                if (sftpClient != null) {
-                                    sftpClient.close();
-                                }
+                            } else {
+                                e.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
+                            }
+                        } finally {
+                            if (sftpClient != null) {
+                                sftpClient.close();
                             }
                         }
-                    });
-                    try {
-                        // the delete is best effort only and if it takes longer than 60 seconds - or the launch
-                        // timeout (if specified) - then we should just give up and leave the file there.
-                        tidyUp.get(launchTimeoutSeconds == null ? 60 : launchTimeoutSeconds, TimeUnit.SECONDS);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
-                        // we should either re-apply our interrupt flag or propagate... we don't want to propagate, so...
-                        Thread.currentThread().interrupt();
-                    } catch (ExecutionException e) {
-                        e.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
-                    } catch (TimeoutException e) {
-                        e.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
-                    } finally {
-                        if (!tidyUp.isDone()) {
-                            tidyUp.cancel(true);
-                        }
+                    }
+                });
+                try {
+                    // the delete is best effort only and if it takes longer than 60 seconds - or the launch
+                    // timeout (if specified) - then we should just give up and leave the file there.
+                    tidyUp.get(launchTimeoutSeconds == null ? 60 : launchTimeoutSeconds, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    e.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
+                    // we should either re-apply our interrupt flag or propagate... we don't want to propagate, so...
+                    Thread.currentThread().interrupt();
+                } catch (ExecutionException e) {
+                    e.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
+                } catch (TimeoutException e) {
+                    e.printStackTrace(listener.error(Messages.SSHLauncher_ErrorDeletingFile(getTimestamp())));
+                } finally {
+                    if (!tidyUp.isDone()) {
+                        tidyUp.cancel(true);
                     }
                 }
-
-                PluginImpl.unregister(connection);
-                cleanupConnection(listener);
             }
+
+            PluginImpl.unregister(connection);
+            cleanupConnection(listener);
         }
     }
 

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -269,10 +269,12 @@ public class SSHLauncher extends ComputerLauncher {
      */
     public final Integer retryWaitTime;
 
+    // TODO: It is a bad idea to create a new Executor service for each launcher.
+    // Maybe a Remoting thread pool should be used, but it requires the logic rework to Futures
     /**
      * Keeps executor service for the async launch operation.
      */
-    @javax.annotation.CheckForNull
+    @CheckForNull
     private transient volatile ExecutorService launcherExecutorService;
 
     /**
@@ -847,7 +849,9 @@ public class SSHLauncher extends ComputerLauncher {
         try {
             long time = System.currentTimeMillis();
             List<Future<Boolean>> results;
-            assert launcherExecutorService != null : "It should be always non-null here, because the task allocates and closes service on its own";
+            if (launcherExecutorService == null) {
+                throw new IllegalStateException("Launcher Executor Service should be always non-null here, because the task allocates and closes service on its own");
+            }
             if (this.getLaunchTimeoutMillis() > 0) {
                 results = launcherExecutorService.invokeAll(callables, this.getLaunchTimeoutMillis(), TimeUnit.MILLISECONDS);
             } else {


### PR DESCRIPTION
There is hanging we see: 

```
"SSHLauncher.launch for 'MyAgent' node [#1]" #559943 prio=5 os_prio=0 tid=0x00007f9b0d994000 nid=0x4ce5 in Object.wait() [0x00007f9ab01b5000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Thread.join(Thread.java:1252)
	- locked <0x000000059e20bea8> (a com.trilead.ssh2.Connection$PumpThread)
	at java.lang.Thread.join(Thread.java:1326)
	at com.trilead.ssh2.Connection.exec(Connection.java:1574)
	at hudson.plugins.sshslaves.SSHLauncher.checkJavaVersion(SSHLauncher.java:1208)
	at hudson.plugins.sshslaves.SSHLauncher.resolveJava(SSHLauncher.java:902)
	at hudson.plugins.sshslaves.SSHLauncher$2.call(SSHLauncher.java:808)
	at hudson.plugins.sshslaves.SSHLauncher$2.call(SSHLauncher.java:792)
```

Both agents may be a problem, because we see hundreds of afterDisconnect() handlers waiting for the lock.

```
"Computer.threadPoolForRemoting [#49225]" #1900616 daemon prio=5 os_prio=0 tid=0x00007f9b5482f800 nid=0x3312 waiting for monitor entry [0x00007f9a0fe40000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at hudson.plugins.sshslaves.SSHLauncher.afterDisconnect(SSHLauncher.java:1336)
	- waiting to lock <0x000000058143f168> (a hudson.plugins.sshslaves.SSHLauncher)
	at hudson.slaves.SlaveComputer$3.run(SlaveComputer.java:633)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
```

If the `launch()` operation hangs, the `afterDisconnect()` command will not interrupt it because it runs in a separate executor service. And, if you have no "launchTimeout" property set, it will hang forever (?).

https://issues.jenkins-ci.org/browse/JENKINS-19465

@reviewbybees 
