### PR TITLE
[JENKINS-48260] Upgrade parent POM and fix PCT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+buildPlugin(jenkinsVersions: [null, '2.73.1'])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>3.0</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>
@@ -24,9 +24,8 @@
   </licenses>
 
   <properties>
-    <jenkins.version>1.625</jenkins.version>
+    <jenkins.version>2.7.1</jenkins.version>
     <java.level>7</java.level>
-    <jenkins-test-harness.version>2.18</jenkins-test-harness.version>
   </properties>
 
   <developers>
@@ -92,6 +91,24 @@
       <groupId>org.jenkins-ci.test</groupId>
       <artifactId>docker-fixtures</artifactId>
       <version>1.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- provided by jenkins-core -->
+          <groupId>com.google.inject</groupId>
+          <artifactId>guice</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- provided by jenkins-core -->
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>annotation-indexer</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-core</artifactId>
+      <version>1.6.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -90,20 +90,8 @@
     <dependency>
       <groupId>org.jenkins-ci.test</groupId>
       <artifactId>docker-fixtures</artifactId>
-      <version>1.0</version>
+      <version>1.4</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <!-- provided by jenkins-core -->
-          <groupId>com.google.inject</groupId>
-          <artifactId>guice</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- provided by jenkins-core -->
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>annotation-indexer</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>2.7.1</jenkins.version>
+    <jenkins.version>1.625</jenkins.version>
     <java.level>7</java.level>
   </properties>
 
@@ -104,12 +104,6 @@
           <artifactId>annotation-indexer</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-core</artifactId>
-      <version>1.6.0</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -52,6 +52,9 @@ import hudson.model.Slave;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.RetentionStrategy;
 import java.util.concurrent.ExecutionException;
+
+import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
 import org.jenkinsci.test.acceptance.docker.DockerRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 import org.junit.Assert;
@@ -74,6 +77,8 @@ import org.jvnet.hudson.test.Issue;
 
 public class SSHLauncherTest {
 
+    private static final VersionNumber JAVA_8_MINIMAL_SINCE = new VersionNumber("2.54");
+
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
 
@@ -85,7 +90,13 @@ public class SSHLauncherTest {
 
     @Test
     public void checkJavaVersionOpenJDK7NetBSD() throws Exception {
-        assertTrue("OpenJDK7 on NetBSD should be supported", checkSupported("openjdk-7-netbsd.version"));
+        final VersionNumber jenkinsVersion = Jenkins.getVersion();
+
+        if(jenkinsVersion.isOlderThan(JAVA_8_MINIMAL_SINCE)) {
+            assertTrue("OpenJDK7 on NetBSD should be supported", checkSupported("openjdk-7-netbsd.version"));
+        } else {
+            assertNotSupported("openjdk-7-netbsd.version");
+        }
     }
 
     @Test
@@ -105,7 +116,13 @@ public class SSHLauncherTest {
 
     @Test
     public void testCheckJavaVersionOracle7Mac() throws Exception {
-        Assert.assertTrue("Oracle 7 on Mac should be supported", checkSupported("oracle-java-1.7-mac.version"));
+        final VersionNumber jenkinsVersion = Jenkins.getVersion();
+
+        if(jenkinsVersion.isOlderThan(JAVA_8_MINIMAL_SINCE)) {
+            Assert.assertTrue("Oracle 7 on Mac should be supported", checkSupported("oracle-java-1.7-mac.version"));
+        } else {
+            assertNotSupported("oracle-java-1.7-mac.version");
+        }
     }
 
     @Test

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -54,7 +54,6 @@ import hudson.slaves.RetentionStrategy;
 import java.util.concurrent.ExecutionException;
 
 import hudson.util.VersionNumber;
-import jenkins.model.Jenkins;
 import org.jenkinsci.test.acceptance.docker.DockerRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 import org.junit.Assert;
@@ -77,8 +76,6 @@ import org.jvnet.hudson.test.Issue;
 
 public class SSHLauncherTest {
 
-    private static final VersionNumber JAVA_8_MINIMAL_SINCE = new VersionNumber("2.54");
-
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
 
@@ -90,9 +87,8 @@ public class SSHLauncherTest {
 
     @Test
     public void checkJavaVersionOpenJDK7NetBSD() throws Exception {
-        final VersionNumber jenkinsVersion = Jenkins.getVersion();
-
-        if(jenkinsVersion.isOlderThan(JAVA_8_MINIMAL_SINCE)) {
+        VersionNumber java7 = new VersionNumber("7");
+        if(JavaProvider.getMinJavaLevel().equals(java7)) {
             assertTrue("OpenJDK7 on NetBSD should be supported", checkSupported("openjdk-7-netbsd.version"));
         } else {
             assertNotSupported("openjdk-7-netbsd.version");
@@ -116,9 +112,8 @@ public class SSHLauncherTest {
 
     @Test
     public void testCheckJavaVersionOracle7Mac() throws Exception {
-        final VersionNumber jenkinsVersion = Jenkins.getVersion();
-
-        if(jenkinsVersion.isOlderThan(JAVA_8_MINIMAL_SINCE)) {
+        VersionNumber java7 = new VersionNumber("7");
+        if(JavaProvider.getMinJavaLevel().equals(java7)) {
             Assert.assertTrue("Oracle 7 on Mac should be supported", checkSupported("oracle-java-1.7-mac.version"));
         } else {
             assertNotSupported("oracle-java-1.7-mac.version");

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
@@ -34,15 +34,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.sshd.SshServer;
+import org.apache.sshd.server.SshServer;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.server.Command;
 import org.apache.sshd.server.CommandFactory;
-import org.apache.sshd.server.PasswordAuthenticator;
-import org.apache.sshd.server.UserAuth;
-import org.apache.sshd.server.auth.UserAuthPassword;
-import org.apache.sshd.server.command.UnknownCommand;
-import org.apache.sshd.server.keyprovider.PEMGeneratorHostKeyProvider;
+import org.apache.sshd.server.auth.password.PasswordAuthenticator;
+import org.apache.sshd.server.auth.UserAuth;
+import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.scp.UnknownCommand;
 import org.apache.sshd.server.session.ServerSession;
 import org.junit.Rule;
 import org.junit.Test;
@@ -95,8 +95,8 @@ public class TrustHostKeyActionTest {
 
         SshServer server = SshServer.setUpDefaultServer();
         server.setPort(port);
-        server.setKeyPairProvider(new PEMGeneratorHostKeyProvider());
-        server.setUserAuthFactories(Arrays.asList((NamedFactory<UserAuth>)new UserAuthPassword.Factory()));
+        server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        server.setUserAuthFactories(Arrays.asList((NamedFactory<UserAuth>)new UserAuthPasswordFactory()));
         server.setCommandFactory(new CommandFactory() {
 
             @Override

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
@@ -24,26 +24,18 @@
 package hudson.plugins.sshslaves.verifiers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.ServerSocket;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.sshd.server.SshServer;
-import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.Command;
-import org.apache.sshd.server.CommandFactory;
-import org.apache.sshd.server.auth.password.PasswordAuthenticator;
-import org.apache.sshd.server.auth.UserAuth;
-import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.scp.UnknownCommand;
-import org.apache.sshd.server.session.ServerSession;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -93,29 +85,33 @@ public class TrustHostKeyActionTest {
         
         final int port = findPort();
 
-        SshServer server = SshServer.setUpDefaultServer();
-        server.setPort(port);
-        server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-        server.setUserAuthFactories(Arrays.asList((NamedFactory<UserAuth>)new UserAuthPasswordFactory()));
-        server.setCommandFactory(new CommandFactory() {
+        try {
+            Object server = newSshServer();
+            assertNotNull(server);
+            Class keyPairProviderClass = newKeyPairProviderClass();
+            Object provider = newProvider();
+            assertNotNull(provider);
+            Object factory = newFactory();
+            assertNotNull(factory);
+            Class commandFactoryClass = newCommandFactoryClass();
+            Object commandFactory = newCommandFactory(commandFactoryClass);
+            assertNotNull(commandFactory);
+            Class commandAuthenticatorClass = newCommandAuthenticatorClass();
+            Object authenticator = newAuthenticator(commandAuthenticatorClass);
+            assertNotNull(authenticator);
 
-            @Override
-            public Command createCommand(final String command) {
-                return new UnknownCommand(command);
-            }
-            
-        });
-        server.setPasswordAuthenticator(new PasswordAuthenticator() {
-            
-            @Override
-            public boolean authenticate(String username, String password, ServerSession session) {
-                return true;
-            }
-        });
+            invoke(server, "setPort", new Class[] {Integer.TYPE}, new Object[] {port});
+            invoke(server, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
+            invoke(server, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
+            invoke(server, "setCommandFactory", new Class[] {commandFactoryClass}, new Object[] {commandFactory});
+            invoke(server, "setPasswordAuthenticator", new Class[] {commandAuthenticatorClass}, new Object[] {authenticator});
 
-        server.start();
-        
-        
+            invoke(server, "start", null, null);
+        } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException | IllegalArgumentException e) {
+            e.printStackTrace();
+            throw new AssertionError("Check sshd-core version");
+        }
+
         SSHLauncher launcher = new SSHLauncher("localhost", port, "dummyCredentialId", null, "xyz", null, null, 30, 1, 1, new ManuallyTrustedKeyVerificationStrategy(true));
         DumbSlave slave = new DumbSlave("test-slave", "SSH Test slave",
                 temporaryFolder.newFolder().getAbsolutePath(), "1", Mode.NORMAL, "",
@@ -144,5 +140,113 @@ public class TrustHostKeyActionTest {
         
         
     }
-    
+
+    private Object newSshServer() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Object server = null;
+        Class serverClass;
+        try {
+            serverClass = Class.forName("org.apache.sshd.SshServer");
+        } catch (ClassNotFoundException e) {
+            serverClass = Class.forName("org.apache.sshd.server.SshServer");
+        }
+
+        return serverClass.getDeclaredMethod("setUpDefaultServer", null).invoke(null);
+    }
+
+    private Class newKeyPairProviderClass() throws ClassNotFoundException {
+        Class keyPairProviderClass;
+        try {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.KeyPairProvider");
+        } catch (ClassNotFoundException e) {
+            keyPairProviderClass = Class.forName("org.apache.sshd.common.keyprovider.KeyPairProvider");
+        }
+
+        return keyPairProviderClass;
+    }
+
+    private Object newProvider() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Object provider = null;
+        Class providerClass;
+        try {
+            providerClass = Class.forName("org.apache.sshd.server.keyprovider.PEMGeneratorHostKeyProvider");
+        } catch (ClassNotFoundException e) {
+            providerClass = Class.forName("org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider");
+        }
+
+        return providerClass.getConstructor().newInstance();
+    }
+
+    private Object newFactory() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Object factory = null;
+        Class factoryClass;
+        try {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.UserAuthPassword$Factory");
+        } catch (ClassNotFoundException e) {
+            factoryClass = Class.forName("org.apache.sshd.server.auth.password.UserAuthPasswordFactory");
+        }
+
+        return factoryClass.getConstructor().newInstance();
+    }
+
+    private Class newCommandFactoryClass() throws ClassNotFoundException {
+        return Class.forName("org.apache.sshd.server.CommandFactory");
+    }
+
+    private Object newCommandFactory(Class commandFactoryClass) throws ClassNotFoundException, IllegalArgumentException {
+        return java.lang.reflect.Proxy.newProxyInstance(
+                commandFactoryClass.getClassLoader(),
+                new java.lang.Class[]{commandFactoryClass},
+                new java.lang.reflect.InvocationHandler() {
+
+                    @Override
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws java.lang.Throwable {
+
+                        if (method.getName().equals("createCommand")) {
+                            Class commandClass;
+                            try {
+                                commandClass = Class.forName("org.apache.sshd.server.command.UnknownCommand");
+                            } catch (ClassNotFoundException e) {
+                                commandClass = Class.forName("org.apache.sshd.server.scp.UnknownCommand");
+                            }
+
+                            return commandClass.getConstructor(String.class).newInstance(args[0]);
+                        }
+
+                        return null;
+                    }
+                });
+    }
+
+    private Class newCommandAuthenticatorClass() throws ClassNotFoundException {
+        Class passwordAuthenticatorClass;
+        try {
+            passwordAuthenticatorClass = Class.forName("org.apache.sshd.server.PasswordAuthenticator");
+        } catch(ClassNotFoundException e) {
+            passwordAuthenticatorClass = Class.forName("org.apache.sshd.server.auth.password.PasswordAuthenticator");
+        }
+
+        return passwordAuthenticatorClass;
+    }
+
+    private Object newAuthenticator(Class passwordAuthenticatorClass) throws ClassNotFoundException, IllegalArgumentException {
+        return java.lang.reflect.Proxy.newProxyInstance(
+                passwordAuthenticatorClass.getClassLoader(),
+                new java.lang.Class[]{passwordAuthenticatorClass},
+                new java.lang.reflect.InvocationHandler() {
+
+                    @Override
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws java.lang.Throwable {
+
+                        if (method.getName().equals("authenticate")) {
+                            return Boolean.TRUE;
+                        }
+
+                        return null;
+                    }
+                });
+    }
+
+    private Object invoke(Object target, String methodName, Class[] parameterTypes, Object[] args) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        return target.getClass().getMethod(methodName, parameterTypes).invoke(target, args);
+    }
 }

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
@@ -108,8 +108,7 @@ public class TrustHostKeyActionTest {
 
             invoke(server, "start", null, null);
         } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException | IllegalArgumentException e) {
-            e.printStackTrace();
-            throw new AssertionError("Check sshd-core version");
+            throw new AssertionError("Check sshd-core version", e);
         }
 
         SSHLauncher launcher = new SSHLauncher("localhost", port, "dummyCredentialId", null, "xyz", null, null, 30, 1, 1, new ManuallyTrustedKeyVerificationStrategy(true));


### PR DESCRIPTION
See [JENKINS-48260](https://issues.jenkins-ci.org/browse/JENKINS-48260)

## Features:

- Upgrade to `parent-pom:3.0` and update dependencies
- Upgrading baseline to `jenkins.version:2.7` to prevent `IndexOutOfBoundsException` when the ExtensionList is recovered.
- `TrustHostKeyActionTest` updated with new dependency `sshd-core:1.6.0`
- `SSHLauncherTest` updated to check if Java 7 is supported depending on `jenkins.version`

@reviewbybees spec. @stephenc 
@olamy 
@mc1arke 