### PR TITLE
[JENKINS-48613] - Hotfix: Prevent piling up of tearDownConnection() calls if they take long

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -125,6 +125,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -240,6 +241,12 @@ public class SSHLauncher extends ComputerLauncher {
      * SSH connection to the slave.
      */
     private transient volatile Connection connection;
+
+    /**
+     * Indicates that the {@link #tearDownConnection(SlaveComputer, TaskListener)} is in progress.
+     * It is used in {@link #afterDisconnect(SlaveComputer, TaskListener)} to avoid multiple parallel calls.
+     */
+    private transient volatile boolean tearingDownConnection;
 
     /**
      * The session inside {@link #connection} that controls the slave process.
@@ -1368,11 +1375,24 @@ public class SSHLauncher extends ComputerLauncher {
             srv.shutdown();
         }
 
+        if (tearingDownConnection) {
+            // tear down operation is in progress, do not even try to synchronize the call.
+            //TODO: what if reconnect attempts collide? It should not be possible due to locks, but maybe it worth investigation
+            LOGGER.log(Level.FINE, "There is already a tear down operation in progress for connection {0}. Skipping the call", connection);
+            return;
+        }
         tearDownConnection(slaveComputer, listener);
     }
 
     private synchronized void tearDownConnection(@Nonnull SlaveComputer slaveComputer, final @Nonnull TaskListener listener) {
         if (connection != null) {
+            tearDownConnectionImpl(slaveComputer, listener);
+        }
+    }
+
+    private void tearDownConnectionImpl(@Nonnull SlaveComputer slaveComputer, final @Nonnull TaskListener listener) {
+        try {
+            tearingDownConnection = true;
             boolean connectionLost = reportTransportLoss(connection, listener);
             if (session!=null) {
                 // give the process 3 seconds to write out its dying message before we cut the loss
@@ -1443,6 +1463,8 @@ public class SSHLauncher extends ComputerLauncher {
 
             PluginImpl.unregister(connection);
             cleanupConnection(listener);
+        } finally {
+            tearingDownConnection = false;
         }
     }
 


### PR DESCRIPTION
It extends my JENKINS-19465 fix in #75 and makes the hack even more hackish.
Ideally Jenkins Core needs to be updated to somehow prevent /queue such duplicated calls in the Executor service. Should be done on a ComputerListener level or so. I will create tickets for that later

@reviewbybees @jglick 
