### PR TITLE
[JENKINS-48616] - Pass launch timeout as Connection and KEx timeout to TrileadSSH

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1299,6 +1299,10 @@ public class SSHLauncher extends ComputerLauncher {
         int maxNumRetries = this.maxNumRetries == null || this.maxNumRetries < 0 ? 0 : this.maxNumRetries;
         for (int i = 0; i <= maxNumRetries; i++) {
             try {
+                // We pass launch timeout so that the connection will be able to abort once it reaches the timeout
+                // It is a poor man's logic, but it should cause termination if the connection goes strongly beyond the timeout
+                //TODO: JENKINS-48617 and JENKINS-48618 need to be implemented to make it fully robust
+                int launchTimeoutMillis = (int)getLaunchTimeoutMillis();
                 connection.connect(new ServerHostKeyVerifier() {
 
                     @Override
@@ -1308,7 +1312,7 @@ public class SSHLauncher extends ComputerLauncher {
 
                         return getSshHostKeyVerificationStrategyDefaulted().verify(computer, key, listener);
                     }
-                });
+                }, launchTimeoutMillis, 0 /*read timeout - JENKINS-48618*/, launchTimeoutMillis);
                 break;
             } catch (IOException ioexception) {
                 @CheckForNull String message = "";


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-48616

It does not make much difference without [JENKINS-48617](https://issues.jenkins-ci.org/browse/JENKINS-48617) and [JENKINS-48618](https://issues.jenkins-ci.org/browse/JENKINS-48618), but OTOH it is a low-hanging fruit.

@reviewbybees @jglick 