### PR TITLE
[FIXED JENKINS-49607] - Report required java version when none found

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -940,7 +940,8 @@ public class SSHLauncher extends ComputerLauncher {
         try {
             return attemptToInstallJDK(listener, workingDirectory);
         } catch (IOException e) {
-            throw new IOException("Could not find any known supported java version in "+tried+", and we also failed to install JDK as a fallback",e);
+            VersionNumber minJavaLevel = JavaProvider.getMinJavaLevel();
+            throw new IOException("Could not find any known supported java version (a minimum level of "+minJavaLevel+" is required) in "+tried+", and we also failed to install JDK as a fallback",e);
         }
     }
 


### PR DESCRIPTION
It will now return:
on jenkins >= JAVA8_MINIMAL_SINCE (=2.54 see JavaProvider.java; Version used defined in jenkins.version of POM.xml)
java.io.IOException: Could not find any known supported java version (a minimum level of 8 is required) in [java, /usr/bin/java, /usr/java/default/bin/java, /usr/java/latest/bin/java, /usr/local/bin/java, /usr/local/java/bin/java, /home/test/slave/jdk/bin/java], and we also failed to install JDK as a fallback

on jenkins < JAVA8_MINIMAL_SINCE (=2.54 see JavaProvider; Version used defined in jenkins.version of POM.xml)
java.io.IOException: Could not find any known supported java version (a minimum level of 7 is required) in [java, /usr/bin/java, /usr/java/default/bin/java, /usr/java/latest/bin/java, /usr/local/bin/java, /usr/local/java/bin/java, /home/test/slave/jdk/bin/java], and we also failed to install JDK as a fallback

During testing I also noted that:
- Automatically installing the DEFAUL_JDK as defined in SSHLauncher.java  does not work anymore and fails with "Oracle now requires Oracle account to download previous versions of JDK. Please specify your Oracle account username/password."
- docker-fixtures have to be updated (the image fails with 1.4 when installing openssh-server=1:7.5p1-10) 1.6 works. (already covered in https://github.com/jenkinsci/ssh-slaves-plugin/pull/82)