### PR TITLE
[JENKINS-49670] SSHLauncherTest#upgrade is failing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.jenkins-ci.test</groupId>
       <artifactId>docker-fixtures</artifactId>
-      <version>1.4</version>
+      <version>1.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
See [JENKINS-49670](https://issues.jenkins-ci.org/browse/JENKINS-49670)

Upgrade docker-fixtures dependency to fix the error when `SSHLauncherTest#upgrade` is executed.

@reviewbybees @olamy @stephenc @oleg-nenashev 