### PR TITLE
[WIP][JENKINS-51876] Updated core, Java version, and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.0</version>
+    <version>3.8</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>
@@ -24,8 +24,8 @@
   </licenses>
 
   <properties>
-    <jenkins.version>1.625</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <developers>
@@ -94,29 +94,21 @@
   </pluginRepositories>
 
   <dependencies>
-    <!-- regular dependencies -->
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-      <version>build-217-jenkins-11</version>
-      <scope>provided</scope>
-      <!-- we only need the newer version for testing, we use the bundled version during execution -->
-    </dependency>
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.2</version>
+      <version>2.1.16</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.6.1</version>
+      <version>1.13</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.test</groupId>
       <artifactId>docker-fixtures</artifactId>
-      <version>1.6</version>
+      <version>1.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
@@ -24,18 +24,27 @@
 package hudson.plugins.sshslaves.verifiers;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.net.ServerSocket;
-import java.util.Arrays;
+import java.security.PublicKey;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.sshd.SshServer;
+import org.apache.sshd.common.util.OsUtils;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.CommandFactory;
+import org.apache.sshd.server.PasswordAuthenticator;
+import org.apache.sshd.server.PublickeyAuthenticator;
+import org.apache.sshd.server.command.ScpCommandFactory;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.session.ServerSession;
+import org.apache.sshd.server.shell.ProcessShellFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -48,11 +57,8 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
-import hudson.model.Node.Mode;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.DumbSlave;
-import hudson.slaves.NodeProperty;
-import hudson.slaves.RetentionStrategy;
 import hudson.slaves.SlaveComputer;
 
 public class TrustHostKeyActionTest {
@@ -79,50 +85,26 @@ public class TrustHostKeyActionTest {
 
         SystemCredentialsProvider.getInstance().getDomainCredentialsMap().put(Domain.global(),
                 Collections.<Credentials>singletonList(
-                        new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "dummyCredentialId", null, "user", "pass")
+                        new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "dummyCredentialId",
+                                                            null, "user", "pass")
                 )
         );
-        
-        final int port = findPort();
 
-        try {
-            Object server = newSshServer();
-            assertNotNull(server);
-            Class keyPairProviderClass = newKeyPairProviderClass();
-            Object provider = newProvider();
-            assertNotNull(provider);
-            Object factory = newFactory();
-            assertNotNull(factory);
-            Class commandFactoryClass = newCommandFactoryClass();
-            Object commandFactory = newCommandFactory(commandFactoryClass);
-            assertNotNull(commandFactory);
-            Class commandAuthenticatorClass = newCommandAuthenticatorClass();
-            Object authenticator = newAuthenticator(commandAuthenticatorClass);
-            assertNotNull(authenticator);
-
-            invoke(server, "setPort", new Class[] {Integer.TYPE}, new Object[] {port});
-            invoke(server, "setKeyPairProvider", new Class[] {keyPairProviderClass}, new Object[] {provider});
-            invoke(server, "setUserAuthFactories", new Class[] {List.class}, new Object[] {Arrays.asList(factory)});
-            invoke(server, "setCommandFactory", new Class[] {commandFactoryClass}, new Object[] {commandFactory});
-            invoke(server, "setPasswordAuthenticator", new Class[] {commandAuthenticatorClass}, new Object[] {authenticator});
-
-            invoke(server, "start", null, null);
-        } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException | IllegalArgumentException e) {
-            throw new AssertionError("Check sshd-core version", e);
-        }
-
-        SSHLauncher launcher = new SSHLauncher("localhost", port, "dummyCredentialId", null, "xyz", null, null, 30, 1, 1, new ManuallyTrustedKeyVerificationStrategy(true));
-        DumbSlave slave = new DumbSlave("test-slave", "SSH Test slave",
-                temporaryFolder.newFolder().getAbsolutePath(), "1", Mode.NORMAL, "",
-                launcher, RetentionStrategy.NOOP, Collections.<NodeProperty<?>>emptyList());
-        
+        int port = findPort();
+        startSshServer(port);
+        SSHLauncher launcher = new SSHLauncher("localhost", port, "dummyCredentialId", null,
+                                               "xyz", null, null,
+                                               30, 1, 1,
+                                               new ManuallyTrustedKeyVerificationStrategy(true));
+        DumbSlave slave = new DumbSlave("test-slave", temporaryFolder.newFolder().getAbsolutePath(), launcher);
         jenkins.getInstance().addNode(slave);
         SlaveComputer computer = (SlaveComputer) jenkins.getInstance().getComputer("test-slave");
 
         try {
             computer.connect(false).get();
         } catch (ExecutionException ex){
-            if (!ex.getMessage().startsWith("java.io.IOException: Slave failed") && !ex.getMessage().startsWith("java.io.IOException: Agent failed")) {
+            if (!ex.getMessage().startsWith("java.io.IOException: Slave failed")
+                && !ex.getMessage().startsWith("java.io.IOException: Agent failed")) {
                 throw ex;
             }
         }
@@ -136,116 +118,37 @@ public class TrustHostKeyActionTest {
         
         assertTrue(actions.get(0).isComplete());
         assertEquals(actions.get(0).getExistingHostKey(), actions.get(0).getHostKey());
-        
-        
     }
 
-    private Object newSshServer() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Object server = null;
-        Class serverClass;
-        try {
-            serverClass = Class.forName("org.apache.sshd.SshServer");
-        } catch (ClassNotFoundException e) {
-            serverClass = Class.forName("org.apache.sshd.server.SshServer");
-        }
-
-        return serverClass.getDeclaredMethod("setUpDefaultServer", null).invoke(null);
-    }
-
-    private Class newKeyPairProviderClass() throws ClassNotFoundException {
-        Class keyPairProviderClass;
-        try {
-            keyPairProviderClass = Class.forName("org.apache.sshd.common.KeyPairProvider");
-        } catch (ClassNotFoundException e) {
-            keyPairProviderClass = Class.forName("org.apache.sshd.common.keyprovider.KeyPairProvider");
-        }
-
-        return keyPairProviderClass;
-    }
-
-    private Object newProvider() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        Object provider = null;
-        Class providerClass;
-        try {
-            providerClass = Class.forName("org.apache.sshd.server.keyprovider.PEMGeneratorHostKeyProvider");
-        } catch (ClassNotFoundException e) {
-            providerClass = Class.forName("org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider");
-        }
-
-        return providerClass.getConstructor().newInstance();
-    }
-
-    private Object newFactory() throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        Object factory = null;
-        Class factoryClass;
-        try {
-            factoryClass = Class.forName("org.apache.sshd.server.auth.UserAuthPassword$Factory");
-        } catch (ClassNotFoundException e) {
-            factoryClass = Class.forName("org.apache.sshd.server.auth.password.UserAuthPasswordFactory");
-        }
-
-        return factoryClass.getConstructor().newInstance();
-    }
-
-    private Class newCommandFactoryClass() throws ClassNotFoundException {
-        return Class.forName("org.apache.sshd.server.CommandFactory");
-    }
-
-    private Object newCommandFactory(Class commandFactoryClass) throws ClassNotFoundException, IllegalArgumentException {
-        return java.lang.reflect.Proxy.newProxyInstance(
-                commandFactoryClass.getClassLoader(),
-                new java.lang.Class[]{commandFactoryClass},
-                new java.lang.reflect.InvocationHandler() {
-
-                    @Override
-                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws java.lang.Throwable {
-
-                        if (method.getName().equals("createCommand")) {
-                            Class commandClass;
-                            try {
-                                commandClass = Class.forName("org.apache.sshd.server.command.UnknownCommand");
-                            } catch (ClassNotFoundException e) {
-                                commandClass = Class.forName("org.apache.sshd.server.scp.UnknownCommand");
-                            }
-
-                            return commandClass.getConstructor(String.class).newInstance(args[0]);
-                        }
-
-                        return null;
-                    }
-                });
-    }
-
-    private Class newCommandAuthenticatorClass() throws ClassNotFoundException {
-        Class passwordAuthenticatorClass;
-        try {
-            passwordAuthenticatorClass = Class.forName("org.apache.sshd.server.PasswordAuthenticator");
-        } catch(ClassNotFoundException e) {
-            passwordAuthenticatorClass = Class.forName("org.apache.sshd.server.auth.password.PasswordAuthenticator");
-        }
-
-        return passwordAuthenticatorClass;
-    }
-
-    private Object newAuthenticator(Class passwordAuthenticatorClass) throws ClassNotFoundException, IllegalArgumentException {
-        return java.lang.reflect.Proxy.newProxyInstance(
-                passwordAuthenticatorClass.getClassLoader(),
-                new java.lang.Class[]{passwordAuthenticatorClass},
-                new java.lang.reflect.InvocationHandler() {
-
-                    @Override
-                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws java.lang.Throwable {
-
-                        if (method.getName().equals("authenticate")) {
-                            return Boolean.TRUE;
-                        }
-
-                        return null;
-                    }
-                });
-    }
-
-    private Object invoke(Object target, String methodName, Class[] parameterTypes, Object[] args) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        return target.getClass().getMethod(methodName, parameterTypes).invoke(target, args);
+    private void startSshServer(int port) throws IOException {
+        SshServer serverSsh = SshServer.setUpDefaultServer();
+        serverSsh.setPort(port);
+        SimpleGeneratorHostKeyProvider keysProvider = new SimpleGeneratorHostKeyProvider();
+        keysProvider.setAlgorithm("RSA");
+        keysProvider.loadKey("RSA");
+        serverSsh.setKeyPairProvider(keysProvider);
+        serverSsh.setCommandFactory(new ScpCommandFactory(new CommandFactory() {
+            public Command createCommand(String command) {
+                EnumSet<ProcessShellFactory.TtyOptions> ttyOptions;
+                if (OsUtils.isUNIX()) {
+                    ttyOptions = EnumSet.of(ProcessShellFactory.TtyOptions.ONlCr);
+                } else {
+                    ttyOptions = EnumSet.of(ProcessShellFactory.TtyOptions.Echo, ProcessShellFactory.TtyOptions.ICrNl,
+                                            ProcessShellFactory.TtyOptions.ONlCr);
+                }
+                return new ProcessShellFactory(command.split(" "), ttyOptions).create();
+            }
+        }));
+        serverSsh.setPasswordAuthenticator(new PasswordAuthenticator() {
+            public boolean authenticate(String username, String password, ServerSession session) {
+                return true;
+            }
+        });
+        serverSsh.setPublickeyAuthenticator(new PublickeyAuthenticator() {
+            public boolean authenticate(String username, PublicKey key, ServerSession session) {
+                return true;
+            }
+        });
+        serverSsh.start();
     }
 }


### PR DESCRIPTION
[JENKINS-51876](https://issues.jenkins-ci.org/browse/JENKINS-51876)

The goal is to sanitize the plugin, it supports a really old core and contains tons of methods deprecated since eons, this is the first step to clean up some stuff.

* Update core to 2.60.3
* Update Java to 8
* Update dependencies to latest stable version
* remove trilead-ssh provided dependency, not need because we upgrade the core
* fix TrustHostKeyActionTest Test, I have removed the reflection to create the SSH server is no longer need, this change is moticated to change from a DSA key to an RSA key required for Java 8.

@reviewbybees 