### PR TITLE
[JENKINS-52015] Separate AccessControlled from CredentialsProvider co…

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1644,7 +1644,8 @@ public class SSHLauncher extends ComputerLauncher {
                                                      @QueryParameter String host,
                                                      @QueryParameter String port,
                                                      @QueryParameter String credentialsId) {
-            if (context == null || !context.hasPermission(Computer.CONFIGURE)) {
+            Jenkins jenkins = Jenkins.getActiveInstance();
+            if ((context == jenkins && !jenkins.hasPermission(Computer.CREATE)) || (context != jenkins && !context.hasPermission(Computer.CONFIGURE))) {
                 return new StandardUsernameListBoxModel()
                         .includeCurrentValue(credentialsId);
             }
@@ -1653,7 +1654,7 @@ public class SSHLauncher extends ComputerLauncher {
                 return new StandardUsernameListBoxModel()
                         .includeMatchingAs(
                                 ACL.SYSTEM,
-                                Jenkins.getActiveInstance(),
+                                jenkins,
                                 StandardUsernameCredentials.class,
                                 Collections.<DomainRequirement>singletonList(
                                         new HostnamePortRequirement(host, portValue)
@@ -1671,7 +1672,8 @@ public class SSHLauncher extends ComputerLauncher {
                                                    @QueryParameter String host,
                                                    @QueryParameter String port,
                                                    @QueryParameter String value) {
-            if (_context == null || !_context.hasPermission(Computer.CONFIGURE)) {
+            Jenkins jenkins = Jenkins.getActiveInstance();
+            if ((_context == jenkins && !jenkins.hasPermission(Computer.CREATE)) || (_context != jenkins && !_context.hasPermission(Computer.CONFIGURE))) {
                 return FormValidation.ok(); // no need to alarm a user that cannot configure
             }
             try {

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1640,12 +1640,11 @@ public class SSHLauncher extends ComputerLauncher {
             return n;
         }
 
-        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context,
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath AccessControlled context,
                                                      @QueryParameter String host,
                                                      @QueryParameter String port,
                                                      @QueryParameter String credentialsId) {
-            AccessControlled _context = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance());
-            if (_context == null || !_context.hasPermission(Computer.CONFIGURE)) {
+            if (context == null || !context.hasPermission(Computer.CONFIGURE)) {
                 return new StandardUsernameListBoxModel()
                         .includeCurrentValue(credentialsId);
             }
@@ -1668,11 +1667,10 @@ public class SSHLauncher extends ComputerLauncher {
         }
 
         public FormValidation doCheckCredentialsId(@AncestorInPath ItemGroup context,
+                                                   @AncestorInPath AccessControlled _context,
                                                    @QueryParameter String host,
                                                    @QueryParameter String port,
                                                    @QueryParameter String value) {
-            AccessControlled _context =
-                    (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance());
             if (_context == null || !_context.hasPermission(Computer.CONFIGURE)) {
                 return FormValidation.ok(); // no need to alarm a user that cannot configure
             }


### PR DESCRIPTION
…ntext

---

[JENKINS-52015](https://issues.jenkins-ci.org/browse/JENKINS-52015)

Also address the weird side effect that during agent creation, there's no `AccessControlled` other than `Jenkins`, so users who only have Agent/Create would need to create the agent first, and then, in a separate step, configure the SSH launcher.

Needs Jenkins 2.78+ so that `Computer` is a `DescriptorByNameOwner`.