### PR TITLE
JENKINS-37152 Replace 'true' with 'echo'

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -967,7 +967,7 @@ public class SSHLauncher extends ComputerLauncher {
      */
     private void verifyNoHeaderJunk(TaskListener listener) throws IOException, InterruptedException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        connection.exec("echo hello > null",baos);
+        connection.exec("exit 0",baos);
         final String s;
         //TODO: Seems we need to retrieve the encoding from the connection destination
         try {

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -967,7 +967,7 @@ public class SSHLauncher extends ComputerLauncher {
      */
     private void verifyNoHeaderJunk(TaskListener listener) throws IOException, InterruptedException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        connection.exec("true",baos);
+        connection.exec("echo hello > null",baos);
         final String s;
         //TODO: Seems we need to retrieve the encoding from the connection destination
         try {


### PR DESCRIPTION
Use echo > null instead of true command in `verifyNoHeaderJunk()`

Using echo instead of true allows to start windows slaves without cygwin.

This is related to ticket: JENKINS-37152