### PR TITLE
[FIXED JENKINS-53254] Restore getJavaPath() method.

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -775,6 +775,16 @@ public class SSHLauncher extends ComputerLauncher {
     }
 
     /**
+     * Gets the optional java command to use to launch the agent JVM.
+     * @return The optional java command to use to launch the agent JVM.
+     */
+    @SuppressWarnings("unused") // Used by vsphere-cloud-plugin
+    @Deprecated
+    public String getJavaPath() {
+        return javaPath == null ? "" : javaPath;
+    }
+
+    /**
      * Gets the formatted current time stamp.
      *
      * @return the formatted current time stamp.


### PR DESCRIPTION
[JENKINS-53254](https://issues.jenkins-ci.org/browse/JENKINS-53254)

It was removed in commit 118423c3de0fd3f5b65183a3f2d62cb2e15a79ca, but
it is still used by at least one plugin.

Mark as deprecated to discourage further use.