### PR TITLE
[JENKINS-54269] Missing display name for administrative monitor

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor.java
@@ -26,6 +26,7 @@ package hudson.plugins.sshslaves.verifiers;
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.Computer;
+import hudson.plugins.sshslaves.Messages;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.SlaveComputer;
@@ -69,5 +70,10 @@ public class MissingVerificationStrategyAdministrativeMonitor extends Administra
             return true;
         }
         return false;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.MissingVerificationStrategyAdministrativeMonitor_DisplayName();
     }
 }

--- a/src/main/resources/hudson/plugins/sshslaves/Messages.properties
+++ b/src/main/resources/hudson/plugins/sshslaves/Messages.properties
@@ -57,3 +57,4 @@ KnownHostsFileHostKeyVerifier.NewKeyNotTrusted={0} [SSH] WARNING: No entry curre
 KnownHostsFileHostKeyVerifier.ChangedKeyNotTrusted={0} [SSH] The SSH key presented by the remote host does not match the key saved in the Known Hosts file against this host. Connections to this host will be denied until the two keys match.
 KnownHostsFileHostKeyVerifier.KeyTrusted={0} [SSH] SSH host key matches key in Known Hosts file. Connection will be allowed.
 KnownHostsFileHostKeyVerifier.NoKnownHostsFile={0} [SSH] No Known Hosts file was found at {0}. Please ensure one is created at this path and that Jenkins can read it.
+MissingVerificationStrategyAdministrativeMonitor.DisplayName=Missing Verification Strategy Monitor


### PR DESCRIPTION
See [JENKINS-54269](https://issues.jenkins-ci.org/browse/JENKINS-54269)

The display name for the MissingVerificationStrategyAdministrativeMonitor is missing. This PR adds its display name.

![seleccion_005](https://user-images.githubusercontent.com/31063239/47562437-b3960600-d91e-11e8-9bc0-eb4c32e3a092.png)

@reviewbybees 
@kuisathaverat as maintainer