### PR TITLE
[JENKINS-54934] Number of retries and retry wait time of 0

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -544,8 +544,8 @@ public class SSHLauncher extends ComputerLauncher {
         this.prefixStartSlaveCmd = fixEmpty(prefixStartSlaveCmd);
         this.suffixStartSlaveCmd = fixEmpty(suffixStartSlaveCmd);
         this.launchTimeoutSeconds = launchTimeoutSeconds == null || launchTimeoutSeconds <= 0 ? DEFAULT_LAUNCH_TIMEOUT_SECONDS : launchTimeoutSeconds;
-        this.maxNumRetries = maxNumRetries != null && maxNumRetries > 0 ? maxNumRetries : DEFAULT_MAX_NUM_RETRIES;
-        this.retryWaitTime = retryWaitTime != null && retryWaitTime > 0 ? retryWaitTime : DEFAULT_RETRY_WAIT_TIME;
+        this.maxNumRetries = maxNumRetries != null && maxNumRetries >= 0 ? maxNumRetries : DEFAULT_MAX_NUM_RETRIES;
+        this.retryWaitTime = retryWaitTime != null && retryWaitTime >= 0 ? retryWaitTime : DEFAULT_RETRY_WAIT_TIME;
         this.sshHostKeyVerificationStrategy = sshHostKeyVerificationStrategy;
     }
 
@@ -1468,7 +1468,7 @@ public class SSHLauncher extends ComputerLauncher {
      */
     @NonNull
     public Integer getRetryWaitTime() {
-        return retryWaitTime == null || retryWaitTime == 0 ? DEFAULT_RETRY_WAIT_TIME : retryWaitTime;
+        return retryWaitTime == null || retryWaitTime < 0 ? DEFAULT_RETRY_WAIT_TIME : retryWaitTime;
     }
 
     public boolean getTcpNoDelay() {

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -357,4 +357,45 @@ public class SSHLauncherTest {
         assertTrue(javas.contains(javaHomeTool + DefaultJavaProvider.BIN_JAVA));
         assertTrue(javas.contains(SSHLauncher.getWorkingDirectory(computer) + DefaultJavaProvider.JDK_BIN_JAVA));
     }
+
+    @Test
+    public void timeoutAndRetrySettings() {
+        final SSHLauncher launcher = new SSHLauncher("Hostname", 22, "credentialID", "jvmOptions",
+                                                    "javaPath", "prefix" , "suffix",
+                                                    39, 18, 25,
+                                                    new NonVerifyingKeyVerificationStrategy());
+        assertEquals(39, launcher.getLaunchTimeoutSeconds().intValue());
+        assertEquals(18, launcher.getMaxNumRetries().intValue());
+        assertEquals(25, launcher.getRetryWaitTime().intValue());
+    }
+
+    @Issue("JENKINS-54934")
+    @Test
+    public void timeoutAndRetrySettingsAllowZero() {
+        final SSHLauncher launcher = new SSHLauncher("Hostname", 22, "credentialID", "jvmOptions",
+                                                    "javaPath", "prefix" , "suffix",
+                                                    0, 0, 0,
+                                                    new NonVerifyingKeyVerificationStrategy());
+        assertEquals(0, launcher.getMaxNumRetries().intValue());
+        assertEquals(0, launcher.getRetryWaitTime().intValue());
+    }
+
+    @Test
+    public void timeoutAndRetrySettingsSetDefaultsIfOutOfRange() {
+        final SSHLauncher launcher = new SSHLauncher("Hostname", 22, "credentialID", "jvmOptions",
+                                                    "javaPath", "prefix" , "suffix",
+                                                    0, -1, -1,
+                                                    new NonVerifyingKeyVerificationStrategy());
+        assertEquals(SSHLauncher.DEFAULT_LAUNCH_TIMEOUT_SECONDS, launcher.getLaunchTimeoutSeconds());
+        assertEquals(SSHLauncher.DEFAULT_MAX_NUM_RETRIES, launcher.getMaxNumRetries());
+        assertEquals(SSHLauncher.DEFAULT_RETRY_WAIT_TIME, launcher.getRetryWaitTime());
+
+        final SSHLauncher launcher2 = new SSHLauncher("Hostname", 22, "credentialID", "jvmOptions",
+                                                    "javaPath", "prefix" , "suffix",
+                                                    null, null, null,
+                                                    new NonVerifyingKeyVerificationStrategy());
+        assertEquals(SSHLauncher.DEFAULT_LAUNCH_TIMEOUT_SECONDS, launcher2.getLaunchTimeoutSeconds());
+        assertEquals(SSHLauncher.DEFAULT_MAX_NUM_RETRIES, launcher2.getMaxNumRetries());
+        assertEquals(SSHLauncher.DEFAULT_RETRY_WAIT_TIME, launcher2.getRetryWaitTime());
+    }
 }


### PR DESCRIPTION
Enables `0`  for the *number of retries* and *retry wait time* (JENKINS-54934).