### PR TITLE
[FIX JENKINS-56147] Overwrite remoting.jar only when necessary.

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1080,7 +1080,7 @@ public class SSHLauncher extends ComputerLauncher {
                 SFTPv3FileAttributes fileAttributes = sftpClient._stat(workingDirectory);
                 if (fileAttributes==null) {
                     listener.getLogger().println(Messages.SSHLauncher_RemoteFSDoesNotExist(getTimestamp(),
-                      workingDirectory));
+                            workingDirectory));
                     sftpClient.mkdirs(workingDirectory, 0700);
                 } else if (fileAttributes.isRegularFile()) {
                     throw new IOException(Messages.SSHLauncher_RemoteFSIsAFile(workingDirectory));
@@ -1109,24 +1109,22 @@ public class SSHLauncher extends ComputerLauncher {
                         // the file did not exist... so no need to delete it!
                     }
 
-                    try ( OutputStream os = sftpClient.writeToFile(fileName)) {
+                    try (OutputStream os = sftpClient.writeToFile(fileName)) {
                         os.write(agentJar);
                         listener.getLogger()
                           .println(Messages.SSHLauncher_CopiedXXXBytes(getTimestamp(), agentJar.length));
-                    } catch ( Error error ) {
+                    } catch (Error error) {
                         throw error;
-                    } catch ( Throwable e ) {
-                        throw new IOException( Messages.SSHLauncher_ErrorCopyingAgentJarTo( fileName ), e );
+                    } catch (Throwable e) {
+                        throw new IOException(Messages.SSHLauncher_ErrorCopyingAgentJarTo(fileName), e);
                     }
                 }else{
                     listener.getLogger().println("Verified agent jar. No update is necessary.");
                 }
-
-
             } catch (Error error) {
                 throw error;
             } catch (Throwable e) {
-                throw new IOException(Messages.SSHLauncher_ErrorCopyingAgentJarInto( workingDirectory), e);
+                throw new IOException(Messages.SSHLauncher_ErrorCopyingAgentJarInto(workingDirectory), e);
             }
         } catch (IOException e) {
             if (sftpClient == null) {

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1087,7 +1087,7 @@ public class SSHLauncher extends ComputerLauncher {
                 }
 
                 listener.getLogger().println(Messages.SSHLauncher_CopyingAgentJar(getTimestamp()));
-                byte[] agentJar = new Slave.JnlpJar( AGENT_JAR ).readFully();
+                byte[] agentJar = new Slave.JnlpJar(AGENT_JAR).readFully();
 
                 // If the agent jar already exists see if it needs to be updated
                 boolean overwrite = true;

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1068,23 +1068,22 @@ public class SSHLauncher extends ComputerLauncher {
      *
      * @throws IOException If something goes wrong.
      */
-    private void copyAgentJar( TaskListener listener, String workingDirectory )
-      throws IOException, InterruptedException {
+    private void copyAgentJar(TaskListener listener, String workingDirectory) throws IOException, InterruptedException {
         String fileName = workingDirectory + SLASH_AGENT_JAR;
 
-        listener.getLogger().println( Messages.SSHLauncher_StartingSFTPClient( getTimestamp() ) );
+        listener.getLogger().println(Messages.SSHLauncher_StartingSFTPClient(getTimestamp()));
         SFTPClient sftpClient = null;
         try {
-            sftpClient = new SFTPClient( connection );
+            sftpClient = new SFTPClient(connection);
 
             try {
-                SFTPv3FileAttributes fileAttributes = sftpClient._stat( workingDirectory );
-                if ( fileAttributes == null ) {
-                    listener.getLogger().println( Messages.SSHLauncher_RemoteFSDoesNotExist( getTimestamp(),
-                        workingDirectory));
-                      sftpClient.mkdirs( workingDirectory, 0700 );
-                } else if ( fileAttributes.isRegularFile() ) {
-                    throw new IOException( Messages.SSHLauncher_RemoteFSIsAFile( workingDirectory ) );
+                SFTPv3FileAttributes fileAttributes = sftpClient._stat(workingDirectory);
+                if (fileAttributes==null) {
+                    listener.getLogger().println(Messages.SSHLauncher_RemoteFSDoesNotExist(getTimestamp(),
+                      workingDirectory));
+                    sftpClient.mkdirs(workingDirectory, 0700);
+                } else if (fileAttributes.isRegularFile()) {
+                    throw new IOException(Messages.SSHLauncher_RemoteFSIsAFile(workingDirectory));
                 }
 
                 listener.getLogger().println(Messages.SSHLauncher_CopyingAgentJar(getTimestamp()));
@@ -1092,28 +1091,28 @@ public class SSHLauncher extends ComputerLauncher {
 
                 // If the agent jar already exists see if it needs to be updated
                 boolean overwrite = true;
-                if ( sftpClient.exists( fileName ) ) {
-                    String sourceAgentHash = getMd5Hash( agentJar );
-                    String existingAgentHash = getMd5Hash( readFileIntoByteArray( sftpClient, fileName ) );
-                    listener.getLogger().println( MessageFormat.format( "Source agent hash is {0}. "
-                      + "Installed agent hash is {1}", sourceAgentHash, existingAgentHash ) );
+                if (sftpClient.exists(fileName)) {
+                    String sourceAgentHash = getMd5Hash(agentJar);
+                    String existingAgentHash = getMd5Hash(readFileIntoByteArray(sftpClient, fileName));
+                    listener.getLogger().println(MessageFormat.format( "Source agent hash is {0}. "
+                      + "Installed agent hash is {1}", sourceAgentHash, existingAgentHash));
 
-                    overwrite = !sourceAgentHash.equals( existingAgentHash );
+                    overwrite = !sourceAgentHash.equals(existingAgentHash);
                 }
 
-                if ( overwrite ) {
+                if (overwrite) {
                     try {
                         // try to delete the file in case the agent we are copying is shorter than the agent
                         // that is already there
-                        sftpClient.rm( fileName );
-                    } catch ( IOException e ) {
+                        sftpClient.rm(fileName);
+                    } catch (IOException e) {
                         // the file did not exist... so no need to delete it!
                     }
 
-                    try ( OutputStream os = sftpClient.writeToFile( fileName ) ) {
-                        os.write( agentJar );
+                    try ( OutputStream os = sftpClient.writeToFile(fileName)) {
+                        os.write(agentJar);
                         listener.getLogger()
-                          .println( Messages.SSHLauncher_CopiedXXXBytes( getTimestamp(), agentJar.length ) );
+                          .println(Messages.SSHLauncher_CopiedXXXBytes(getTimestamp(), agentJar.length));
                     } catch ( Error error ) {
                         throw error;
                     } catch ( Throwable e ) {
@@ -1124,12 +1123,12 @@ public class SSHLauncher extends ComputerLauncher {
                 }
 
 
-            } catch ( Error error ) {
+            } catch (Error error) {
                 throw error;
-            } catch ( Throwable e ) {
-                throw new IOException( Messages.SSHLauncher_ErrorCopyingAgentJarInto( workingDirectory ), e );
+            } catch (Throwable e) {
+                throw new IOException(Messages.SSHLauncher_ErrorCopyingAgentJarInto( workingDirectory), e);
             }
-        } catch ( IOException e ) {
+        } catch (IOException e) {
             if (sftpClient == null) {
                 e.printStackTrace(listener.error(Messages.SSHLauncher_StartingSCPClient(getTimestamp())));
                 // lets try to recover if the agent doesn't have an SFTP service
@@ -1150,16 +1149,15 @@ public class SSHLauncher extends ComputerLauncher {
      * @return
      * @throws NoSuchAlgorithmException
      */
-
-    String getMd5Hash(byte[] bytes) throws NoSuchAlgorithmException {
+    private String getMd5Hash(byte[] bytes) throws NoSuchAlgorithmException {
 
         String hash = "";
         try {
-            MessageDigest md = MessageDigest.getInstance( "MD5" );
-            md.update( bytes );
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.update(bytes);
             byte[] digest = md.digest();
-            hash = DatatypeConverter.printHexBinary( digest ).toUpperCase();
-        }catch ( NoSuchAlgorithmException e ){
+            hash = DatatypeConverter.printHexBinary(digest).toUpperCase();
+        }catch (NoSuchAlgorithmException e){
             throw e;
         } finally {
             return hash;
@@ -1172,13 +1170,13 @@ public class SSHLauncher extends ComputerLauncher {
      * @return
      * @throws Exception
      */
-    byte[] readFileIntoByteArray(SFTPClient sftpClient, String fileName) throws Exception {
+    private byte[] readFileIntoByteArray(SFTPClient sftpClient, String fileName) throws Exception {
 
         InputStream is = null;
         byte[] bytes = null;
         try{
-            is = sftpClient.read( fileName );
-            bytes = ByteStreams.toByteArray( is );
+            is = sftpClient.read(fileName);
+            bytes = ByteStreams.toByteArray(is);
         }catch(Exception e){
             throw e;
         } finally {

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -30,6 +30,8 @@ import hudson.model.JDK;
 import hudson.plugins.sshslaves.verifiers.KnownHostsFileKeyVerificationStrategy;
 import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy;
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -58,6 +60,7 @@ import java.util.concurrent.ExecutionException;
 import hudson.slaves.SlaveComputer;
 import hudson.tools.ToolLocationNodeProperty;
 import hudson.util.VersionNumber;
+import org.apache.commons.io.IOUtils;
 import org.jenkinsci.test.acceptance.docker.DockerRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 import org.junit.Assert;
@@ -75,6 +78,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
 import org.junit.ClassRule;
 import org.jvnet.hudson.test.BuildWatcher;
 import jenkins.model.Jenkins;
@@ -398,4 +402,40 @@ public class SSHLauncherTest {
         assertEquals(SSHLauncher.DEFAULT_MAX_NUM_RETRIES, launcher2.getMaxNumRetries());
         assertEquals(SSHLauncher.DEFAULT_RETRY_WAIT_TIME, launcher2.getRetryWaitTime());
     }
+
+  @Test
+  public void getMd5Hash() {
+
+    try {
+      byte[] bytes = "Leave me alone!".getBytes();
+      String result = SSHLauncher.getMd5Hash(bytes);
+      assertTrue( "1EB226C8E950BAC1494BE197E84A264C".equals(result));
+    }catch(Exception e){
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void readInputStreamIntoByteArrayAndClose() {
+
+    InputStream inputStream = null;
+    File testFile = null;
+    try {
+
+      testFile = new File("target" + File.separator + "test-classes",
+        "readInputStreamIntoByteArrayTestFile.txt" );
+      assertTrue(testFile.exists());
+      inputStream = new FileInputStream(testFile);
+      byte[] bytes = SSHLauncher.readInputStreamIntoByteArrayAndClose(inputStream);
+      assertNotNull(bytes);
+      assertTrue(bytes.length > 0);
+      assertTrue( "Don't change me or add newlines!".equals(new String(bytes)) );
+
+    }catch(Exception e){
+      e.printStackTrace();
+    }finally {
+      IOUtils.closeQuietly(inputStream);
+    }
+  }
+
 }

--- a/src/test/resources/readInputStreamIntoByteArrayTestFile.txt
+++ b/src/test/resources/readInputStreamIntoByteArrayTestFile.txt
@@ -1,0 +1,1 @@
+Don't change me or add newlines!


### PR DESCRIPTION
When an ssh agent is launched it will compare the MD5 hash of the remoting jar in Jenkins home with the hash of the remoting.jar in the remote root directory of the agent.

* If the file does not exist or is different, it is copied from the Jenkins master.
* If the file is the same, it is ignored.

This change allows multiple agent nodes to share the same root directory (and workspace) without getting concurrency conflicts that happened when the remoting jar got overwritten with every agent launch.

See https://issues.jenkins-ci.org/browse/JENKINS-5149 and similar.

see the related issue [JENKINS-56147](https://issues.jenkins-ci.org/browse/JENKINS-56147)