### PR TITLE
[JENKINS-57018] Allow to enable/disable TCP_NODELAY in SSHConnector

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
@@ -107,8 +107,13 @@ public class SSHConnector extends ComputerConnector {
      *  Field retryWaitTime.
      */
     private Integer retryWaitTime;
-    
+
     private SshHostKeyVerificationStrategy sshHostKeyVerificationStrategy;
+
+    /**
+     *  Field tcpNoDelay.
+     */
+    private Boolean tcpNoDelay;
 
     /**
      * Constructor SSHLauncher creates a new SSHLauncher instance.
@@ -135,10 +140,12 @@ public class SSHConnector extends ComputerConnector {
      * @param maxNumRetries The number of times to retry connection if the SSH connection is refused during initial connect
      * @param retryWaitTime The number of seconds to wait between retries
      * @param sshHostKeyVerificationStrategy Host key verification method selected.
+     * @param tcpNoDelay Allow to enable/disable the TCP_NODELAY flag on the SSH connection.
      */
     public SSHConnector(int port, String credentialsId, String jvmOptions, String javaPath,
                         String prefixStartSlaveCmd, String suffixStartSlaveCmd, Integer launchTimeoutSeconds,
-                        Integer maxNumRetries, Integer retryWaitTime, SshHostKeyVerificationStrategy sshHostKeyVerificationStrategy) {
+                        Integer maxNumRetries, Integer retryWaitTime, SshHostKeyVerificationStrategy sshHostKeyVerificationStrategy,
+                        Boolean tcpNoDelay) {
         setJvmOptions(jvmOptions);
         setPort(port);
         this.credentialsId = credentialsId;
@@ -151,12 +158,15 @@ public class SSHConnector extends ComputerConnector {
         setLaunchTimeoutSeconds(launchTimeoutSeconds);
         setMaxNumRetries(maxNumRetries);
         setRetryWaitTime(retryWaitTime);
+        setTcpNoDelay(tcpNoDelay);
     }
 
     @Override
     public SSHLauncher launch(String host, TaskListener listener) {
-        return new SSHLauncher(host, port, credentialsId, jvmOptions, javaPath, prefixStartSlaveCmd,
-                suffixStartSlaveCmd, launchTimeoutSeconds, maxNumRetries, retryWaitTime, sshHostKeyVerificationStrategy);
+        SSHLauncher sshLauncher = new SSHLauncher(host, port, credentialsId, jvmOptions, javaPath, prefixStartSlaveCmd,
+            suffixStartSlaveCmd, launchTimeoutSeconds, maxNumRetries, retryWaitTime, sshHostKeyVerificationStrategy);
+        sshLauncher.setTcpNoDelay(tcpNoDelay);
+        return sshLauncher;
     }
 
     @DataBoundSetter
@@ -202,7 +212,12 @@ public class SSHConnector extends ComputerConnector {
     public void setPort(int value){
         this.port = value == 0 ? DEFAULT_SSH_PORT : value;
     }
-    
+
+    @DataBoundSetter
+    public void setTcpNoDelay(Boolean tcpNoDelay) {
+        this.tcpNoDelay = tcpNoDelay;
+    }
+
     public SshHostKeyVerificationStrategy getSshHostKeyVerificationStrategy() {
     	return sshHostKeyVerificationStrategy;
     }
@@ -245,6 +260,10 @@ public class SSHConnector extends ComputerConnector {
 
     public Integer getRetryWaitTime() {
         return retryWaitTime;
+    }
+
+    public Boolean getTcpNoDelay() {
+        return tcpNoDelay != null ? tcpNoDelay : true;
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
@@ -165,7 +165,7 @@ public class SSHConnector extends ComputerConnector {
     public SSHLauncher launch(String host, TaskListener listener) {
         SSHLauncher sshLauncher = new SSHLauncher(host, port, credentialsId, jvmOptions, javaPath, prefixStartSlaveCmd,
             suffixStartSlaveCmd, launchTimeoutSeconds, maxNumRetries, retryWaitTime, sshHostKeyVerificationStrategy);
-        sshLauncher.setTcpNoDelay(tcpNoDelay);
+        sshLauncher.setTcpNoDelay(getTcpNoDelay());
         return sshLauncher;
     }
 

--- a/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHConnector.java
@@ -140,12 +140,10 @@ public class SSHConnector extends ComputerConnector {
      * @param maxNumRetries The number of times to retry connection if the SSH connection is refused during initial connect
      * @param retryWaitTime The number of seconds to wait between retries
      * @param sshHostKeyVerificationStrategy Host key verification method selected.
-     * @param tcpNoDelay Allow to enable/disable the TCP_NODELAY flag on the SSH connection.
      */
     public SSHConnector(int port, String credentialsId, String jvmOptions, String javaPath,
                         String prefixStartSlaveCmd, String suffixStartSlaveCmd, Integer launchTimeoutSeconds,
-                        Integer maxNumRetries, Integer retryWaitTime, SshHostKeyVerificationStrategy sshHostKeyVerificationStrategy,
-                        Boolean tcpNoDelay) {
+                        Integer maxNumRetries, Integer retryWaitTime, SshHostKeyVerificationStrategy sshHostKeyVerificationStrategy) {
         setJvmOptions(jvmOptions);
         setPort(port);
         this.credentialsId = credentialsId;
@@ -158,7 +156,6 @@ public class SSHConnector extends ComputerConnector {
         setLaunchTimeoutSeconds(launchTimeoutSeconds);
         setMaxNumRetries(maxNumRetries);
         setRetryWaitTime(retryWaitTime);
-        setTcpNoDelay(tcpNoDelay);
     }
 
     @Override


### PR DESCRIPTION
This utilizes the change introduced by #90. Essentially it allows the new setting can be set for instances of SSHConnector. Effectively, we can change and persist this setting in the ec2-fleet-plugin when SSHConnector is used as a launcher.

[JENKINS-57018](https://issues.jenkins-ci.org/browse/JENKINS-57018)