### PR TITLE
Java 11 readiness: build both on JDK8 and JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,7 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+def buildConfiguration = buildPlugin.recommendedConfigurations()
+
+// Also build on recent weekly
+buildConfiguration << [ platform: "linux",   jdk: "11", jenkins: "2.168", javaLevel: "8" ]
+buildConfiguration << [ platform: "windows", jdk: "11", jenkins: "2.168", javaLevel: "8" ]
+
+buildPlugin(configurations: buildConfiguration)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,1 @@
-buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ],
-  [ platform: "windows", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ],
-  [ platform: "linux", jdk: "11", jenkins: "2.168", javaLevel: "8" ],
-  [ platform: "windows", jdk: "11", jenkins: "2.168", javaLevel: "8" ]
-])
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.40</version>
+    <version>3.42</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>


### PR DESCRIPTION
Work in progress to make sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))

@jenkinsci/java11-support 