### PR TITLE
[JENKINS-57797] Support Configuration-as-Code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
   <properties>
     <jenkins.version>2.150.1</jenkins.version>
     <java.level>8</java.level>
+    <configuration-as-code.version>1.17</configuration-as-code.version>
   </properties>
 
   <developers>
@@ -123,6 +124,19 @@
           <artifactId>commons-io</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>configuration-as-code-support</artifactId>
+      <version>1.17</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${configuration-as-code.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>configuration-as-code-support</artifactId>
-      <version>1.17</version>
+      <version>${configuration-as-code.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,8 @@
   <properties>
     <jenkins.version>2.150.1</jenkins.version>
     <java.level>8</java.level>
-    <configuration-as-code.version>1.17</configuration-as-code.version>
+    <!-- TODO fix once released -->
+    <configuration-as-code.version>1.20-20190604.105601-2</configuration-as-code.version>
   </properties>
 
   <developers>
@@ -106,7 +107,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.18</version>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -126,17 +127,17 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>io.jenkins.configuration-as-code</groupId>
-      <artifactId>configuration-as-code-support</artifactId>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
       <version>${configuration-as-code.version}</version>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <version>${configuration-as-code.version}</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
-      <type>test-jar</type>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1224,7 +1224,7 @@ public class SSHLauncher extends ComputerLauncher {
     }
 
     @Extension
-    @Symbol("ssh")
+    @Symbol({"sSHLauncher", "ssh"})
     public static class DescriptorImpl extends Descriptor<ComputerLauncher> {
 
         // TODO move the authentication storage to descriptor... see SubversionSCM.java

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -1224,7 +1224,7 @@ public class SSHLauncher extends ComputerLauncher {
     }
 
     @Extension
-    @Symbol({"sSHLauncher", "ssh"})
+    @Symbol({"ssh", "sSHLauncher"})
     public static class DescriptorImpl extends Descriptor<ComputerLauncher> {
 
         // TODO move the authentication storage to descriptor... see SubversionSCM.java

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -70,6 +70,7 @@ import java.util.Collections;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -1223,6 +1224,7 @@ public class SSHLauncher extends ComputerLauncher {
     }
 
     @Extension
+    @Symbol("ssh")
     public static class DescriptorImpl extends Descriptor<ComputerLauncher> {
 
         // TODO move the authentication storage to descriptor... see SubversionSCM.java

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCRoundTripTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCRoundTripTest.java
@@ -1,0 +1,37 @@
+package hudson.plugins.sshslaves;
+
+import hudson.model.Node;
+import hudson.slaves.SlaveComputer;
+import io.jenkins.plugins.casc.misc.ExportImportRoundTripAbstractTest;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class SSHLauncherCasCRoundTripTest extends ExportImportRoundTripAbstractTest {
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        final Node node = r.j.jenkins.getNode("this-ssh-agent");
+        assertNotNull(node);
+
+        SlaveComputer computer = (SlaveComputer) node.toComputer();
+        assertNotNull(computer);
+
+        SSHLauncher launcher = (SSHLauncher) computer.getLauncher();
+        assertNotNull(launcher);
+
+        assertEquals("ssh-host", launcher.getHost());
+        assertEquals(2222, launcher.getPort());
+        assertEquals("-DuberImportantParam=uberImportantValue", launcher.getJvmOptions());
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "hudson.slaves.DumbSlave.name = this-ssh-agent";
+    }
+
+    @Override
+    protected String configResource() {
+        return "SSHCasCConfig.yml";
+    }
+}

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCSupport.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCSupport.java
@@ -17,6 +17,16 @@ public class SSHLauncherCasCSupport {
     @Test
     @ConfiguredWithCode("SSHCasCConfig.yml")
     public void shouldBeAbleToConfigureSSHSlaves() {
+        validateConfiguration();
+    }
+
+    @Test
+    @ConfiguredWithCode("SSHCasCConfigLegacy.yml")
+    public void shouldBeAbleToConfigureLegacySSHSlaves() {
+        validateConfiguration();
+    }
+
+    private void validateConfiguration() {
         final Node node = j.jenkins.getNode("this-ssh-agent");
         assertNotNull(node);
 

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCSupport.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCSupport.java
@@ -1,0 +1,33 @@
+package hudson.plugins.sshslaves;
+
+import hudson.model.Node;
+import hudson.slaves.SlaveComputer;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class SSHLauncherCasCSupport {
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("SSHCasCConfig.yml")
+    public void shouldBeAbleToConfigureSSHSlaves() {
+        final Node node = j.jenkins.getNode("this-ssh-agent");
+        assertNotNull(node);
+
+        SlaveComputer computer = (SlaveComputer) node.toComputer();
+        assertNotNull(computer);
+
+        SSHLauncher launcher = (SSHLauncher) computer.getLauncher();
+        assertNotNull(launcher);
+
+        assertEquals("ssh-host", launcher.getHost());
+        assertEquals(2222, launcher.getPort());
+        assertEquals("-DuberImportantParam=uberImportantValue", launcher.getJvmOptions());
+    }
+}

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCSupportTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCSupportTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class SSHLauncherCasCSupport {
+public class SSHLauncherCasCSupportTest {
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
 

--- a/src/test/resources/hudson/plugins/sshslaves/SSHCasCConfig.yml
+++ b/src/test/resources/hudson/plugins/sshslaves/SSHCasCConfig.yml
@@ -1,0 +1,10 @@
+jenkins:
+  nodes:
+    - permanent:
+        name: "this-ssh-agent"
+        remoteFS: "/home/jenkins"
+        launcher:
+          ssh:
+            host: ssh-host
+            port: 2222
+            jvmOptions: "-DuberImportantParam=uberImportantValue"

--- a/src/test/resources/hudson/plugins/sshslaves/SSHCasCConfigLegacy.yml
+++ b/src/test/resources/hudson/plugins/sshslaves/SSHCasCConfigLegacy.yml
@@ -1,0 +1,10 @@
+jenkins:
+  nodes:
+    - permanent:
+        name: "this-ssh-agent"
+        remoteFS: "/home/jenkins"
+        launcher:
+          sSHLauncher:
+            host: ssh-host
+            port: 2222
+            jvmOptions: "-DuberImportantParam=uberImportantValue"


### PR DESCRIPTION
[JENKINS-57797](https://issues.jenkins-ci.org/browse/JENKINS-57797)

This PR aims to validate the support of configuration-as-code for this plugin.

By default, the configuration is supported, but under the section `sSHLauncher`, this is why I added the `@Symbol` on the `SSHLauncher` descriptor.