### PR TITLE
[JENKINS-57797] Update Casc version and rename classes to fit the parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,7 @@
   <properties>
     <jenkins.version>2.150.1</jenkins.version>
     <java.level>8</java.level>
-    <!-- TODO fix once released -->
-    <configuration-as-code.version>1.20-20190604.105601-2</configuration-as-code.version>
+    <configuration-as-code.version>1.20</configuration-as-code.version>
   </properties>
 
   <developers>

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCRoundTripTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCRoundTripTest.java
@@ -2,13 +2,13 @@ package hudson.plugins.sshslaves;
 
 import hudson.model.Node;
 import hudson.slaves.SlaveComputer;
-import io.jenkins.plugins.casc.misc.ExportImportRoundTripAbstractTest;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class SSHLauncherCasCRoundTripTest extends ExportImportRoundTripAbstractTest {
+public class SSHLauncherCasCRoundTripTest extends RoundTripAbstractTest {
     @Override
     protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
         final Node node = r.j.jenkins.getNode("this-ssh-agent");


### PR DESCRIPTION
Update the casc version and the name of the class because the parent class was renamed at the last minute.

CC: @alecharp @kuisathaverat 