### PR TITLE
[JENKINS-57126] Support alternative drive letters for Windows ssh agents using PowerShell/Win32-OpenSSH

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -614,6 +614,7 @@ public class SSHLauncher extends ComputerLauncher {
             // exceptions here will only disable the alternativeWindowsDriveCheck
             logger.println(Messages.SSHLauncher_UnableToGetEnvironment(getTimestamp()));
             alternativeWindowsDriveCheck=false;
+            Thread.currentThread().interrupt();
         }
         Matcher windowsDriveMatcher = windowsDrivePattern.matcher(workingDirectory);
         String cdArguments = "";

--- a/src/main/resources/hudson/plugins/sshslaves/Messages.properties
+++ b/src/main/resources/hudson/plugins/sshslaves/Messages.properties
@@ -59,3 +59,4 @@ KnownHostsFileHostKeyVerifier.ChangedKeyNotTrusted={0} [SSH] The SSH key present
 KnownHostsFileHostKeyVerifier.KeyTrusted={0} [SSH] SSH host key matches key in Known Hosts file. Connection will be allowed.
 KnownHostsFileHostKeyVerifier.NoKnownHostsFile={0} [SSH] No Known Hosts file was found at {0}. Please ensure one is created at this path and that Jenkins can read it.
 MissingVerificationStrategyAdministrativeMonitor.DisplayName=Missing Verification Strategy Monitor
+SSHLauncher.UnableToGetEnvironment={0} Unable to resolve environment variable OSTYPE, disabling hudson.plugins.sshslaves.alternativewindowsdrive


### PR DESCRIPTION
As per https://issues.jenkins-ci.org/browse/JENKINS-57126

## Issue

If you are using [PowerShell/Win32-OpenSSH](https://github.com/PowerShell/Win32-OpenSSH/releases/tag/v8.0.0.0p1-Beta) and you set the "Remote root directory" to a drive other than the "C:\" (such as somewhere on the `D:\`), the agent will fail to launch with the error:

```
[04/20/19 09:21:29] [SSH] Starting agent process: cd "D:\jenkins-agent" && "C:\Program Files (x86)\Java\jre1.8.0_201\bin\java.exe" -jar remoting.jar -workDir D:\jenkins-agent
Error: Unable to access jarfile remoting.jar
Slave JVM has terminated. Exit code=1
[04/20/19 09:21:29] Launch failed - cleaning up connection
```
## Root cause

The root cause appears to be that the command `cd "D:\jenkins-agent"` does not successfully change to the `D:\` drive, because when using Windows command prompt, you need to add the `/d` argument `cd` to change the drive:

> /d : Changes the current drive or the current directory for a drive.

As per https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cd

## Proposed changes

With the changes from this PR, the `/d` argument is passed if the "Remote root directory" appears to be a Windows-like path, and Cygwin is not detected.

## Testing done

I've tested this PR using a fresh instance of Jenkins LTS 2.176.1
I installed the "recommended" plugins from the initial setup wizard, then I installed my snapshot of the ssh-slaves-plugin.


### PowerShell/Win32-OpenSSH Testing
I tested that `PowerShell/Win32-OpenSSH` now supports the `remote root directory` to be on the `D:\` drive (specifically I tested `D:\j`) on a fresh EC2 instance running:
>  Microsoft Windows Server 2019 Base - ami-09ef280df1a6a5330

I installed PowerShell/Win32-OpenSSH version:
>  https://github.com/PowerShell/Win32-OpenSSH/releases/tag/v8.0.0.0p1-Beta

and I setup ssh by following the `On earlier versions of Windows` and also `Configuring SSH server` from:
>  https://winscp.net/eng/docs/guide_windows_openssh_server

The agent connected successfully and the startup logs were:

```
[06/24/19 16:43:40] [SSH] Starting agent process: cd /d "D:\j" && "C:\Program Files (x86)\Java\jre1.8.0_211\bin\java.exe"  -jar remoting.jar -workDir D:\j
Jun 24, 2019 8:43:40 PM org.jenkinsci.remoting.engine.WorkDirManager initializeWorkDir
INFO: Using D:\j\remoting as a remoting work directory
Both error and output logs will be printed to D:\j\remoting

<===[JENKINS REMOTING CAPACITY]===>channel started
Remoting version: 3.29
This is a Windows agent

Agent successfully connected and online
```

### Cygwin testing

I also tested that Cygwin ssh agents are not affected by this change by starting a fresh EC2 instance running:
>  Microsoft Windows Server 2019 Base - ami-09ef280df1a6a5330

and I setup ssh by following:
>  https://go.cloudbees.com/docs/cloudbees-core/cloud-admin-guide/agents/#_microsoft_windows

then I confirmed that the "/d" argument is not passed to "cd" for Cygwin ssh agents.

### Testing to disable this feature

I also tested that if I start Jenkins with:

```
 java -Dhudson.plugins.sshslaves.alternativewindowsdrive=false -jar jenkins.war
```

this feature is successfully disabled.