### PR TITLE
[JENKINS-58340] docker-plugin-1.1.6 docker cloud does not work with >=ssh-slaves-plugin-1.30.0

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -862,7 +862,13 @@ public class SSHLauncher extends ComputerLauncher {
     }
 
     private void checkConfig() throws InterruptedException {
-        DescriptorImpl descriptor = (DescriptorImpl) this.getDescriptor();
+        //JENKINS-58340 some plugins does not implement Descriptor
+        Descriptor descriptorOrg = Jenkins.get().getDescriptor(this.getClass());
+        if (!(descriptorOrg instanceof DescriptorImpl)) {
+            return;
+        }
+
+        DescriptorImpl descriptor = (DescriptorImpl) descriptorOrg;
         String message = "Validate configuration:\n";
         boolean isValid = true;
 


### PR DESCRIPTION
see [JENKINS-58340](https://issues.jenkins-ci.org/browse/JENKINS-58340)

