### PR TITLE
Remove dead code for no-longer-supported baselines

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor.java
@@ -30,10 +30,7 @@ import hudson.plugins.sshslaves.Messages;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.SlaveComputer;
-import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
 
 /**
  * An administrative warning that checks all SSH slaves have a {@link SshHostKeyVerificationStrategy}
@@ -56,19 +53,6 @@ public class MissingVerificationStrategyAdministrativeMonitor extends Administra
             }
         }
 
-        return false;
-    }
-
-    //TODO: This method can be removed when the baseline is updated to 2.103.
-    /**
-     * @return true if this version of the plugin is running on a Jenkins version where JENKINS-43786 is included.
-     */
-    @Restricted(DoNotUse.class)
-    public boolean isTheNewDesignAvailable() {
-        final VersionNumber version = Jenkins.getVersion();
-        if (version != null && version.isNewerThan(new VersionNumber("2.103"))) {
-            return true;
-        }
         return false;
     }
 

--- a/src/main/resources/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor/message.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor/message.jelly
@@ -24,16 +24,8 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 
-<j:if test="${!it.isTheNewDesignAvailable}">
-<div class="warning">
-  <p>SSH Host Key Verifiers are not configured for all SSH slaves on this Jenkins instance. This could leave these slaves open to man-in-the-middle attacks. <a href="${rootURL}/computer/">Update your slave configuration</a> to resolve this.</p>
-</div>
-</j:if>
-
-<j:if test="${it.isTheNewDesignAvailable}">
 <div class="alert alert-warning">
     SSH Host Key Verifiers are not configured for all SSH slaves on this Jenkins instance. This could leave these slaves open to man-in-the-middle attacks. <a href="${rootURL}/computer/">Update your slave configuration</a> to resolve this.
 </div>
-</j:if>
 
 </j:jelly>


### PR DESCRIPTION
I was perusing the source tree while debugging an unrelated issue and came across this TODO. The TODO was added in #70. At the time, this plugin's baseline was 1.625, so #70 needed a way to support Jenkins core versions both with [JENKINS-43786](https://issues.jenkins-ci.org/browse/JENKINS-43786) (i.e., 2.103 and later) and without it. This plugin's baseline is now 2.150.1, which does contain [JENKINS-43786](https://issues.jenkins-ci.org/browse/JENKINS-43786). So now the logic to support older baselines is dead code that can be removed.

To test this change, I ran `mvn clean package` locally. It passed. Please let me know if there is any additional testing I should do.