### PR TITLE
[JENKINS-56187] manually provided key verification strategy crashes

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy.java
@@ -119,7 +119,7 @@ public class ManuallyProvidedKeyVerificationStrategy extends SshHostKeyVerificat
             try {
                 ManuallyProvidedKeyVerificationStrategy.parseKey(key);
                 return FormValidation.ok();
-            } catch (KeyParseException ex) {
+            } catch (KeyParseException|IllegalArgumentException ex) {
                 return FormValidation.error(ex.getMessage());
             }
         }

--- a/src/main/resources/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy/config.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
     </j:if>           
 
 	<f:entry title="${%SSH Key}" field="key">
-		<f:textarea />
+		<f:textarea checkMethod="post"/>
 	</f:entry>
 
 </j:jelly>


### PR DESCRIPTION
see [JENKINS-56187](https://issues.jenkins-ci.org/browse/JENKINS-56187)

* catch IllegalArgumentException to avoid show the exception in the UI
* sent the public key using POST method to prevent too long GET request errors