### PR TITLE
[JENKINS-44111] add also jar cache dir parameter

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -132,6 +132,8 @@ public class SSHLauncher extends ComputerLauncher {
     public static final String AGENT_JAR = "remoting.jar";
     public static final String SLASH_AGENT_JAR = "/" + AGENT_JAR;
     public static final String WORK_DIR_PARAM = " -workDir ";
+    public static final String JAR_CACHE_PARAM = " -jar-cache ";
+    public static final String JAR_CACHE_DIR = "/remoting/jarCache";
     public static final int DEFAULT_SSH_PORT = 22;
 
     /**
@@ -1218,13 +1220,13 @@ public class SSHLauncher extends ComputerLauncher {
     @Restricted(NoExternalUse.class)
     public String getWorkDirParam(@NonNull String workingDirectory){
         String ret;
-        if(getSuffixStartSlaveCmd().contains(WORK_DIR_PARAM)){
+        if(getSuffixStartSlaveCmd().contains(WORK_DIR_PARAM) || getSuffixStartSlaveCmd().contains(JAR_CACHE_PARAM)){
             //the parameter is already set on suffixStartSlaveCmd
             ret = "";
         } else if (StringUtils.isNotBlank(getWorkDir())){
-            ret = WORK_DIR_PARAM + getWorkDir();
+            ret = WORK_DIR_PARAM + getWorkDir() + JAR_CACHE_PARAM + getWorkDir() + JAR_CACHE_DIR;
         } else {
-            ret = WORK_DIR_PARAM + workingDirectory;
+            ret = WORK_DIR_PARAM + workingDirectory + JAR_CACHE_PARAM + workingDirectory + JAR_CACHE_DIR;
         }
         return ret;
     }

--- a/src/main/resources/hudson/plugins/sshslaves/SSHConnector/help-workDir.html
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHConnector/help-workDir.html
@@ -1,6 +1,6 @@
 <div>
     The <i>Remoting work directory</i> is an internal data storage, which may be used by Remoting to store caches, logs and other metadata.
     For more details see <a href="https://github.com/jenkinsci/remoting/blob/master/docs/workDir.md#remoting-work-directory">Remoting Work directory</a>
-    If remoting parameter "-workDir PATH" is set in <i>Suffix Start Agent Command</i> this field will be ignored.
+    If remoting parameter "-workDir PATH" or "-jar-cache PATH" is set in <i>Suffix Start Agent Command</i> this field will be ignored.
     If empty, the <i>Remote root directory</i> is used as <i>Remoting Work directory</i>
 </div>

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -64,6 +64,8 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import static hudson.plugins.sshslaves.SSHLauncher.JAR_CACHE_DIR;
+import static hudson.plugins.sshslaves.SSHLauncher.JAR_CACHE_PARAM;
 import static hudson.plugins.sshslaves.SSHLauncher.WORK_DIR_PARAM;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -273,7 +275,7 @@ public class SSHLauncherTest {
                                                "javaPath", "prefix" ,"suffix",
                                                60,10, 15, new NonVerifyingKeyVerificationStrategy());
         //use rootFS
-        Assert.assertEquals(launcher.getWorkDirParam(rootFS), WORK_DIR_PARAM + rootFS);
+        Assert.assertEquals(launcher.getWorkDirParam(rootFS), WORK_DIR_PARAM + rootFS + JAR_CACHE_PARAM + rootFS + JAR_CACHE_DIR);
 
         launcher = new SSHLauncher("Hostname", 22, "credentialID", "jvmOptions",
                                    "javaPath", "prefix" , "suffix" + WORK_DIR_PARAM + anotherWorkDir,
@@ -289,7 +291,7 @@ public class SSHLauncherTest {
                                    60,10, 15, new NonVerifyingKeyVerificationStrategy());
         //user the workDir set in configuration
         launcher.setWorkDir(anotherWorkDir);
-        Assert.assertEquals(launcher.getWorkDirParam(rootFS), WORK_DIR_PARAM + anotherWorkDir);
+        Assert.assertEquals(launcher.getWorkDirParam(rootFS), WORK_DIR_PARAM + anotherWorkDir + JAR_CACHE_PARAM + anotherWorkDir + JAR_CACHE_DIR);
     }
 
     @Issue("JENKINS-53245")


### PR DESCRIPTION
see [JENKINS-44111](https://issues.jenkins-ci.org/browse/JENKINS-44111)

it adds also the `-jar-cache` parameter to move the jar cache to the folder WORKDIR/remoting/jarCache