### PR TITLE
[JENKINS-54897] block connection when a connection exists

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -399,6 +399,10 @@ public class SSHLauncher extends ComputerLauncher {
         final int port = this.port;
         checkConfig();
         synchronized (this) {
+            if(connection != null){
+                listener.getLogger().println(Messages.SSHLauncher_alreadyConnected());
+                return;
+            }
             connection = new Connection(host, port);
             launcherExecutorService = Executors.newSingleThreadExecutor(
                     new NamingThreadFactory(Executors.defaultThreadFactory(), "SSHLauncher.launch for '" + computer.getName() + "' node"));

--- a/src/main/resources/hudson/plugins/sshslaves/Messages.properties
+++ b/src/main/resources/hudson/plugins/sshslaves/Messages.properties
@@ -39,6 +39,7 @@ SSHLauncher.PortNotSpecified=The port must be specified
 SSHLauncher.PortLessThanZero=The port value must be greater than 0
 SSHLauncher.PortMoreThan65535=The port value must be less than 65536
 SSHLauncher.HostNotSpecified=The Host must be specified
+SSHLauncher.alreadyConnected=The Agent is connected, disconnect it before to try to connect it again.
 ManualTrustingHostKeyVerifier.KeyNotTrusted={0} [SSH] WARNING: The SSH key for this host is not currently trusted. Connections will be denied until this new key is authorised.
 ManualTrustingHostKeyVerifier.KeyAutoTrusted={0} [SSH] The SSH key with fingerprint {1} has been automatically trusted for connections to this machine.
 ManualTrustingHostKeyVerifier.KeyTrusted={0} [SSH] SSH host key matches key seen previously for this host. Connection will be allowed.


### PR DESCRIPTION
see [JENKINS-54897](https://issues.jenkins-ci.org/browse/JENKINS-54897)

it is possible to start several launch process at the same time, this end in a mess that many of times do not start the agent. This will stop to try to launch an Agent if it is connected or in the process.