### PR TITLE
[JENKINS-59251] Update JCasC to version with security fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.150.1</jenkins.version>
     <java.level>8</java.level>
-    <configuration-as-code.version>1.20</configuration-as-code.version>
+    <configuration-as-code.version>1.29</configuration-as-code.version>
   </properties>
 
   <developers>

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCRoundTripTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherCasCRoundTripTest.java
@@ -27,7 +27,7 @@ public class SSHLauncherCasCRoundTripTest extends RoundTripAbstractTest {
 
     @Override
     protected String stringInLogExpected() {
-        return "hudson.slaves.DumbSlave.name = this-ssh-agent";
+        return "Setting class hudson.plugins.sshslaves.SSHLauncher. host = ssh-host";
     }
 
     @Override


### PR DESCRIPTION
See [JENKINS-59251](https://issues.jenkins-ci.org/browse/JENKINS-59251)

Current version of JCasC is 1.29 and it includes important security fixes introduced in 1.25 and 1.27 (See https://github.com/jenkinsci/configuration-as-code-plugin/releases).

v1.25 also introduces some breaking changes, so to be sure the plugin remains compatible with JCasC, it's worth to update the dependency.

@kuisathaverat 
@oleg-nenashev @MRamonLeon @alecharp @varyvol @rsandell 