### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
 
   <name>Jenkins SSH Slaves plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/SSH+Slaves+plugin</url>
+  <url>https://github.com/jenkinsci/ssh-slaves-plugin</url>
   <description>Allows to launch agents over SSH, using a Java implementation of the SSH protocol</description>
 
   <licenses>


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A
In the case of the plugin the GitHub documentation is a bit more informative ATM.
Maybe we should add a screenshot to the README to have all content from Wiki there.
