### PR TITLE
[JENKINS-59728] Bump Jenkins core to 2.190.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,13 @@
-def buildConfiguration = buildPlugin.recommendedConfigurations()
+//def buildConfiguration = buildPlugin.recommendedConfigurations()
 
-// Also build on recent weekly
-buildConfiguration << [ platform: "linux",   jdk: "11", jenkins: "2.170", javaLevel: "8" ]
-buildConfiguration << [ platform: "windows", jdk: "11", jenkins: "2.170", javaLevel: "8" ]
+def buildConfiguration = [
+  [ platform: "linux",   jdk: "8", jenkins: "2.190.1", javaLevel: "8" ],
+  [ platform: "windows", jdk: "8", jenkins: "2.190.1", javaLevel: "8" ],
+  [ platform: "linux",   jdk: "11", jenkins: "2.190.1", javaLevel: "8" ],
+  [ platform: "windows", jdk: "11", jenkins: "2.190.1", javaLevel: "8" ],
+  // Also build on recent weekly
+  [ platform: "linux",   jdk: "11", jenkins: "2.197", javaLevel: "8" ],
+  [ platform: "windows", jdk: "11", jenkins: "2.197", javaLevel: "8" ]
+]
 
 buildPlugin(configurations: buildConfiguration)

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,51 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.26</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>1.7.26</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>1.7.26</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-jdk14</artifactId>
+        <version>1.7.26</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
   <dependencies>
     <!-- plugin dependencies -->
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.2.0</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.16</version>
+      <version>1.18</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.45</version>
+    <version>3.50</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
   </licenses>
 
   <properties>
-    <revision>1.30.3</revision>
+    <revision>1.31.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.150.1</jenkins.version>
+    <jenkins.version>2.190.1</jenkins.version>
     <java.level>8</java.level>
     <configuration-as-code.version>1.30</configuration-as-code.version>
   </properties>
@@ -102,8 +102,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
-      <version>1.0.3</version>
-      <scope>test</scope>
+      <version>1.0.5</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -149,7 +148,7 @@
         <extensions>true</extensions>
         <configuration>
           <minimumJavaVersion>1.8</minimumJavaVersion>
-          <compatibleSinceVersion>1.30.0</compatibleSinceVersion>
+          <compatibleSinceVersion>1.31.0</compatibleSinceVersion>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
See [JENKINS-59728](https://issues.jenkins-ci.org/browse/JENKINS-59728).

because Jenkins core 2.190.1 no longer has trilead-ssh2, I've to bump the core to 1.90.1 and include trilead-api-plugin as a dependency. I will maintain 1.30.x versions for previous cores for awhile.

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

