### PR TITLE
[ssh-slaves-2.0] [JENKINS-59728] Bump Jenkins core to 2.190.1 (#153)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,13 @@
-def buildConfiguration = buildPlugin.recommendedConfigurations()
+//def buildConfiguration = buildPlugin.recommendedConfigurations()
 
-// Also build on recent weekly
-buildConfiguration << [ platform: "linux",   jdk: "11", jenkins: "2.170", javaLevel: "8" ]
-buildConfiguration << [ platform: "windows", jdk: "11", jenkins: "2.170", javaLevel: "8" ]
+def buildConfiguration = [
+  [ platform: "linux",   jdk: "8", jenkins: "2.190.1", javaLevel: "8" ],
+  [ platform: "windows", jdk: "8", jenkins: "2.190.1", javaLevel: "8" ],
+  [ platform: "linux",   jdk: "11", jenkins: "2.190.1", javaLevel: "8" ],
+  [ platform: "windows", jdk: "11", jenkins: "2.190.1", javaLevel: "8" ],
+  // Also build on recent weekly
+  [ platform: "linux",   jdk: "11", jenkins: "2.197", javaLevel: "8" ],
+  [ platform: "windows", jdk: "11", jenkins: "2.197", javaLevel: "8" ]
+]
 
 buildPlugin(configurations: buildConfiguration)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>3.50</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>
@@ -25,7 +25,9 @@
   </licenses>
 
   <properties>
-    <jenkins.version>2.150.1</jenkins.version>
+    <revision>2.0.0</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <jenkins.version>2.190.1</jenkins.version>
     <java.level>8</java.level>
     <configuration-as-code.version>1.20</configuration-as-code.version>
   </properties>
@@ -95,23 +97,65 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.26</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>1.7.26</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>1.7.26</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-jdk14</artifactId>
+        <version>1.7.26</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
   <dependencies>
     <!-- plugin dependencies -->
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
-      <version>1.0.3</version>
-      <scope>test</scope>
+      <version>1.0.5</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.2.0</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.16</version>
+      <version>1.18</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.test</groupId>
@@ -147,7 +191,7 @@
         <extensions>true</extensions>
         <configuration>
           <minimumJavaVersion>1.8</minimumJavaVersion>
-          <compatibleSinceVersion>1.30.0</compatibleSinceVersion>
+          <compatibleSinceVersion>1.31.0</compatibleSinceVersion>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Backports the following commits to ssh-slaves-2.0:
 - [JENKINS-59728] Bump Jenkins core to 2.190.1  (#153)