### PR TITLE
[ssh-slaves-2.0] [JENKINS-42840] Slave to agent renaming (leftovers) (#151)

### DIFF
--- a/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config_zh_TW.properties
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config_zh_TW.properties
@@ -23,5 +23,5 @@
 Port=\u9023\u63a5\u57e0
 JavaPath=Java \u8def\u5f91
 JVM\ Options=JVM \u9078\u9805\u53c3\u6578
-Prefix\ Start\ Agent\ Command=Slave \u555f\u52d5\u6307\u4ee4\u524d\u7f6e\u5b57\u4e32
-Suffix\ Start\ Agent\ Command=Slave \u555f\u52d5\u6307\u4ee4\u5f8c\u7db4\u5b57\u4e32
+Prefix\ Start\ Agent\ Command=Agent \u555f\u52d5\u6307\u4ee4\u524d\u7f6e\u5b57\u4e32
+Suffix\ Start\ Agent\ Command=Agent \u555f\u52d5\u6307\u4ee4\u5f8c\u7db4\u5b57\u4e32

--- a/src/main/resources/hudson/plugins/sshslaves/SSHLauncher/help.properties
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHLauncher/help.properties
@@ -20,6 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-blurb=Starts a slave by sending commands over a secure SSH connection. \
-	The slave needs to be reachable from the master, and you will have to supply an \
+blurb=Starts an agent by sending commands over a secure SSH connection. \
+	The agent needs to be reachable from the master, and you will have to supply an \
 	account that can log in on the target machine. No root privileges are required.

--- a/src/main/resources/hudson/plugins/sshslaves/SSHLauncher/help_de.properties
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHLauncher/help_de.properties
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-blurb=Startet einen Slave durch Kommandos, die \u00FCber eine gesicherte SSH-Verbindung \
+blurb=Startet einen Agent durch Kommandos, die \u00FCber eine gesicherte SSH-Verbindung \
 	gesendet werden. \
-	Der Slave muss dazu vom Master aus erreichbar sein, und Sie m\u00FCssen einen \
-	Benutzeraccount mit Login-Rechten auf dem Slave angeben. \
-	Root-Rechte sind f\u00FCr diesen Account nicht erforderlich. 
+	Der Agent muss dazu vom Master aus erreichbar sein, und Sie m\u00FCssen einen \
+	Benutzeraccount mit Login-Rechten auf dem Agent angeben. \
+	Root-Rechte sind f\u00FCr diesen Account nicht erforderlich.

--- a/src/main/resources/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor/message.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor/message.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
 
 <j:if test="${it.isTheNewDesignAvailable}">
 <div class="alert alert-warning">
-    SSH Host Key Verifiers are not configured for all SSH slaves on this Jenkins instance. This could leave these slaves open to man-in-the-middle attacks. <a href="${rootURL}/computer/">Update your slave configuration</a> to resolve this.
+    SSH Host Key Verifiers are not configured for all SSH agents on this Jenkins instance. This could leave these agents open to man-in-the-middle attacks. <a href="${rootURL}/computer/">Update your agent configuration</a> to resolve this.
 </div>
 </j:if>
 

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -170,12 +170,12 @@ public class SSHLauncherTest {
         SSHLauncher launcher = new SSHLauncher(host, 123, "dummyCredentialId");
         launcher.setSshHostKeyVerificationStrategy(new KnownHostsFileKeyVerificationStrategy());
         assertEquals(host.trim(), launcher.getHost());
-        DumbSlave slave = new DumbSlave("slave", j.createTmpDir().getPath(), launcher);
+        DumbSlave slave = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
         j.jenkins.addNode(slave);
 
         HtmlPage p = j.createWebClient().getPage(slave, "configure");
         j.submit(p.getFormByName("config"));
-        Slave n = (Slave) j.jenkins.getNode("slave");
+        Slave n = (Slave) j.jenkins.getNode("agent");
 
         assertNotSame(n,slave);
         assertNotSame(n.getLauncher(),launcher);
@@ -223,7 +223,7 @@ public class SSHLauncherTest {
           )
         );
         SSHLauncher launcher = new SSHLauncher("localhost", 123, "dummyCredentialId");
-        DumbSlave slave = new DumbSlave("slave", j.createTmpDir().getPath(), launcher);
+        DumbSlave slave = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
 
         Fingerprint fingerprint = CredentialsProvider.getFingerprintOf(credentials);
         assertThat("No fingerprint created until use", fingerprint, nullValue());
@@ -248,7 +248,7 @@ public class SSHLauncherTest {
           )
         );
         SSHLauncher launcher = new SSHLauncher("localhost", 123, "dummyCredentialId");
-        DumbSlave slave = new DumbSlave("slave", j.createTmpDir().getPath(), launcher);
+        DumbSlave slave = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
 
         Fingerprint fingerprint = CredentialsProvider.getFingerprintOf(credentials);
         assertThat("No fingerprint created until use", fingerprint, nullValue());
@@ -299,7 +299,7 @@ public class SSHLauncherTest {
         String javaHomeTool = "/java_home_tool";
 
         SSHLauncher sshLauncher = new SSHLauncher("Hostname", 22, "credentialID");
-        DumbSlave slave = new DumbSlave("slave" + j.jenkins.getNodes().size(), "/home/test/slave", sshLauncher);
+        DumbSlave slave = new DumbSlave("agent" + j.jenkins.getNodes().size(), "/home/test/agent", sshLauncher);
         j.jenkins.addNode(slave);
         SlaveComputer computer = slave.getComputer();
 

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
@@ -106,12 +106,12 @@ public class TrustHostKeyActionTest {
         }
 
         SSHLauncher launcher = new SSHLauncher("localhost", port, "dummyCredentialId", null, "xyz", null, null, 30, 1, 1, new ManuallyTrustedKeyVerificationStrategy(true));
-        DumbSlave slave = new DumbSlave("test-slave", "SSH Test slave",
+        DumbSlave slave = new DumbSlave("test-agent", "SSH Test agent",
                 temporaryFolder.newFolder().getAbsolutePath(), "1", Mode.NORMAL, "",
                 launcher, RetentionStrategy.NOOP, Collections.emptyList());
         
         jenkins.getInstance().addNode(slave);
-        SlaveComputer computer = (SlaveComputer) jenkins.getInstance().getComputer("test-slave");
+        SlaveComputer computer = (SlaveComputer) jenkins.getInstance().getComputer("test-agent");
 
         try {
             computer.connect(false).get();


### PR DESCRIPTION
Backports the following commits to ssh-slaves-2.0:
 - [JENKINS-42840] Slave to agent renaming (leftovers)  (#151)