### PR TITLE
[JENKINS-53720] JDK11 Build Flow: FindBugs fails with RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE in some classes

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -652,6 +652,9 @@ public class SSHLauncher extends ComputerLauncher {
      *
      * @throws IOException If something goes wrong.
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+      justification="there is a bug related with Java 11 bytecode see https://github.com/spotbugs/spotbugs/issues/756")
     private void copyAgentJar(TaskListener listener, String workingDirectory) throws IOException, InterruptedException {
         String fileName = workingDirectory + SLASH_AGENT_JAR;
 


### PR DESCRIPTION
See [JENKINS-53720](https://issues.jenkins-ci.org/browse/JENKINS-53720).

### Submitter checklist

- [X] JIRA issue is well described

