### PR TITLE
Revert "[JENKINS-47510] RemoteLauncher.isUnix() is not overridden - always returns master OS"

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/RemoteLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/RemoteLauncher.java
@@ -27,7 +27,6 @@ import com.trilead.ssh2.ChannelCondition;
 import com.trilead.ssh2.Connection;
 import com.trilead.ssh2.Session;
 import hudson.FilePath;
-import hudson.Functions;
 import hudson.Launcher;
 import hudson.Proc;
 import hudson.Util;
@@ -141,9 +140,4 @@ final class RemoteLauncher extends Launcher {
     public void kill(Map<String, String> modelEnvVars) throws IOException, InterruptedException {
         // no way to do this
     }
-
-  @Override
-  public boolean isUnix() {
-    return !Functions.isWindows();
-  }
 }


### PR DESCRIPTION
Reverts jenkinsci/ssh-slaves-plugin#168