### PR TITLE
[JENKINS-42840] - Cleanup the "slave" mention leftovers in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * See [GitHub Releases](https://github.com/jenkinsci/ssh-slaves-plugin/releases)
 
 ### 1.30.1 (Jul 21, 2019)
-* [JENKINS-58340](https://issues.jenkins-ci.org/browse/JENKINS-58340) docker-plugin-1.1.6 docker cloud does not work with >=ssh-slaves-plugin-1.30.0
+* [JENKINS-58340](https://issues.jenkins-ci.org/browse/JENKINS-58340) docker-plugin-1.1.6 Docker cloud does not work with 1.30.0
 
 #### Breaking changes
 * see 1.30.0
@@ -66,7 +66,7 @@
 
 ### 1.28.1 (Sep 5, 2018)
 
-* [JENKINS-53254](https://issues.jenkins-ci.org/browse/JENKINS-53254) SSH connection fails in vSphere cloud plugin with a new version of SSH slaves plugin (1.27)
+* [JENKINS-53254](https://issues.jenkins-ci.org/browse/JENKINS-53254) SSH connection fails in vSphere cloud plugin with a new version of the plugin (1.27)
 
 #### Breaking changes
 
@@ -84,8 +84,8 @@
 
 * [JENKINS-51876](https://issues.jenkins-ci.org/browse/JENKINS-51876) Update Core and Java version, remove deprecated code
 * [JENKINS-52660](https://issues.jenkins-ci.org/browse/JENKINS-52660) Allow to disable TCP_NODELAY
-* [JENKINS-42840](https://issues.jenkins-ci.org/browse/JENKINS-42840) Slave to agent Renaming: SSH Slaves Plugin
-* [JENKINS-44111](https://issues.jenkins-ci.org/browse/JENKINS-44111) Enable Remoting work dir by default in SSH Slaves Plugin
+* [JENKINS-42840](https://issues.jenkins-ci.org/browse/JENKINS-42840) Replace "slave" term to agent in the built-in documentation
+* [JENKINS-44111](https://issues.jenkins-ci.org/browse/JENKINS-44111) Enable Remoting work dir by default in the Plugin
 * [JENKINS-52613](https://issues.jenkins-ci.org/browse/JENKINS-52613), [JENKINS-52739](https://issues.jenkins-ci.org/browse/JENKINS-52739) configure 10 retries, 15 seconds between retries, and a timeout of about 210 seconds to connect to the agent.
 * [JENKINS-47586](https://issues.jenkins-ci.org/browse/JENKINS-47586) Removes JDK installer
 * [JENKINS-37152](https://issues.jenkins-ci.org/browse/JENKINS-37152) Support Win32-OpenSSH
@@ -104,7 +104,7 @@
 * [PR #82](https://github.com/jenkinsci/ssh-slaves-plugin/pull/82) - Do not lookup for credentials in SSHLauncher constructor so that the launcher can be initialized before the Credentials store is fully loaded (for Configuration-as-Code plugin)
 
 ### 1.25.1 (Jan 26, 2018)
-* [JENKINS-49032](https://issues.jenkins-ci.org/browse/JENKINS-49032) - Revert usage of "exec" command so that SSH Slaves can connect to Windows agents (regression in 1.25)
+* [JENKINS-49032](https://issues.jenkins-ci.org/browse/JENKINS-49032) - Revert usage of "exec" command so that SSH Node Launcher can connect to Windows agents (regression in 1.25)
 
 ### 1.25 (Jan 05, 2018)
 * [JENKINS-48616](https://issues.jenkins-ci.org/browse/JENKINS-48616) - Pass connection timeouts to socket connection logic if launch timeout is defined in agent settings
@@ -190,16 +190,16 @@
 * Enforce timeout for connection cleanup (possible fix for [JENKINS-14332](https://issues.jenkins-ci.org/browse/JENKINS-14332))
 
 ### 1.6 (Feb 5, 2014)
-* Add initial connection timeout to prevent stalled connections from preventing slave connection.
+* Add initial connection timeout to prevent stalled connections from preventing agent connection.
 * Update credentials plugin to 1.9.4 and ssh-credentials to 1.6.1 to ensure the in-place addition of credentials is available.
 * Change the hard-coded JDK from 1.6.0_16 to 1.6.0_45
 
 ### 1.5 (Oct 16, 2013)
 * Fix to how credentials are sourced for the drop-down list
-* Use credentials plugin's *c:select/* so that when credentials plugin adds the ability for in-place credential addition this can be picked up without modifying ssh-slaves
+* Use credentials plugin's *c:select/* so that when credentials plugin adds the ability for in-place credential addition this can be picked up without modifying the agents
 
 ### 1.4 (Oct 8, 2013)
-* Fixed issue with Slave log on Jenkins 1.521+ ([JENKINS-19758](https://issues.jenkins-ci.org/browse/JENKINS-19758))
+* Fixed issue with agent log on Jenkins 1.521+ ([JENKINS-19758](https://issues.jenkins-ci.org/browse/JENKINS-19758))
 
 ### 1.3 (Oct 4, 2013)
 * Reworked the upgrading of credentials logic. Should be much improved and result in a true minimal initial set
@@ -232,14 +232,14 @@
 * Performance improvement on bulk data transfer when used in a large latency/high bandwidth network ([JENKINS-7813](https://issues.jenkins-ci.org/browse/JENKINS-7813))
 
 ### 0.22 (Dec 07, 2012)
-* Find slave.jar even when running from hudson-dev:run.
+* Find `slave.jar` even when running from hudson-dev:run.
 * Allow environment variables to be declared in the java path, that are then expanded according to environment variables declared on the node or globally.
 
 ### 0.21 (Oct 26, 2011)
-* Slave is slow copying maven artifacts to master ([JENKINS-3922](https://issues.jenkins-ci.org/browse/JENKINS-3922)).
+* Agent is slow copying maven artifacts to master ([JENKINS-3922](https://issues.jenkins-ci.org/browse/JENKINS-3922)).
 
 ### 0.20 (Sep 28, 2011)
-* JDK installation on SSH slaves with newer Jenkins was broken ([JENKINS-10641](https://issues.jenkins-ci.org/browse/JENKINS-10641))
+* On-demand JDK installation on agents with newer Jenkins was broken ([JENKINS-10641](https://issues.jenkins-ci.org/browse/JENKINS-10641))
 
 ### 0.19 (Aug 25, 2011)
 * Fixed possible NPE during error recovery
@@ -255,7 +255,7 @@
 * Improved error diagnostics for unreadable SSH private key file.
 
 ### 0.15 (Mar 26, 2011)
-* New field to be able to configure the java command to use to start the slave
+* New field to be able to configure the java command to use to start the agent
 
 ### 0.14 (Nov 2, 2010)
 * Delete file via ssh if SFTP is not available ([JENKINS-7006](https://issues.jenkins-ci.org/browse/JENKINS-7006))
@@ -267,7 +267,7 @@
 ### 0.12 (June 1, 2010)
 * Avoid "password argument is null" error ([JENKINS-6620](https://issues.jenkins-ci.org/browse/JENKINS-6620))
 * Version check of JDKs was broken in locales that don't use '.' as the floating point separator ([JENKINS-6441](https://issues.jenkins-ci.org/browse/JENKINS-6441))
-* If SFTP is not available on the slave, use SCP ([JENKINS-6239](https://issues.jenkins-ci.org/browse/JENKINS-6239))
+* If SFTP is not available on the node, use SCP ([JENKINS-6239](https://issues.jenkins-ci.org/browse/JENKINS-6239))
 * Hudson fails to detect JVM versions when loading older data ([JENKINS-4856](https://issues.jenkins-ci.org/browse/JENKINS-4856))
 
 ### 0.10 (May 2, 2010)
@@ -291,7 +291,7 @@
 * User name can be now omitted, which defaults to the user that's running the Hudson master.
 
 ### 0.5 (April 28, 2009)
-* Added support for specifying the Slave JVM options
+* Added support for specifying the agent JVM options
 
 ### 0.4 (February 2, 2009)
 * Unknown

--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -1,4 +1,5 @@
-# SSH Slaves plugin
+# Configuring the SSH Build Agents plugin
+
 This plugin allows you to manage an agent running on \*nix machines over SSH. It adds a new type of agent launch method.
 This launch method will
 
@@ -7,8 +8,8 @@ This launch method will
 * Copy the latest remoting.jar via SFTP (falling back to scp if SFTP is not available)
 * Start the remoting process.
 
-# Prerequisites
-Before you start to use the **SSH Slaves Plugin** with your agents, you need to prepare your agents to run the remoting process.
+## Prerequisites
+Before you start to use the the plugin with your agents, you need to prepare your agents to run the remoting process.
 This means that **you have to install a JDK/JRE 8 on your agent** in order to run the *remoting.jar* process.
 
 The agent should have **enough memory** to run the remoting process and the builds. 
@@ -20,9 +21,9 @@ You will have to supply an account that can log in on the target machine. No roo
 Finally the agent should have **permissions to read and write on the work directory**, and **enough disk space** to store *remoting.jar* (~1MB),
 logs (~10MB should be enough), and your build workspaces (it depends on your builds, probably a few GB).
 
-# Configure a Node to use SSH Slaves plugin
+## Configure a Node to use the SSH Build Agents plugin
 
-## Create a Node
+### Create a Node
 First of all, we have to create a node. Go to `Manage Jenkins/Manage Nodes`. 
 
 ![](images/new-node-button.png)
@@ -56,11 +57,11 @@ You will use them to select it as agent for a build. Multiple labels must be sep
 
 ![](images/ssh-node-basic-config.png)
 
-## Configure Launch agents via SSH
+### Configure Launch agents via SSH
 
 Once you selected the **Launch method** to **Launch agents via SSH**, you can configure your SSH agent settings.
 
-### Required settings
+#### Required settings
 
 * **Host:** Hostname or IP of the agent, it should be resolvable and reachable from the Jenkins instance. 
 * **Credentials:** Select the credentials to be used for logging in to the remote host. See [Integration with SSH Credentials Plugin](#integration-with-ssh-credentials-plugin)
@@ -68,9 +69,9 @@ Once you selected the **Launch method** to **Launch agents via SSH**, you can co
 
 ![](images/ssh-node-launcher-config.png)
 
-### Advanced settings
+#### Advanced settings
 
-* **Port:** The TCP port on which the slave's SSH daemon is listening, usually 22.
+* **Port:** The TCP port on which the agent's SSH daemon is listening, usually 22.
 * **JavaPath** This Java path will be used to start the JVM. (/mycustomjdkpath/bin/java) If empty Jenkins will search Java command in the agent.
 * **JVM Options** Additional arguments for the JVM such as min and max heap size, garbage collector options, and other tuning settings.
 * **Prefix Start Agent Command** What you enter here will be prepended to the launch command.
@@ -92,11 +93,11 @@ If empty, the **Remote root directory** is used as **Remoting Work directory**
 
 ![](images/ssh-node-advanced-config.png)
 
-## Host Key Verification Strategy
+### Host Key Verification Strategy
 
 Controls how Jenkins verifies the SSH key presented by the remote host whilst connecting.
 
-### Known hosts file Verification Strategy
+#### Known hosts file Verification Strategy
 
 ![](images/hkvs-known-hosts.png)
 
@@ -108,7 +109,7 @@ This method does not make any updates to the Known Hosts file, instead using the
 someone with suitable access to the appropriate user account on the Jenkins master to update the file as required,
 potentially using the ssh hostname command to initiate a connection and update the file appropriately.
 
-### Manually provided key Verification Strategy
+#### Manually provided key Verification Strategy
 
 ![](images/hkvs-manual-key.png)
 
@@ -117,7 +118,7 @@ Checks the key provided by the remote host matches the key set by the user who c
 The SSH key expected for this connection. This key should be in the form `algorithm value`
 where algorithm is one of ssh-rsa or ssh-dss, and value is the Base 64 encoded content of the key. The keys should be placed in /etc/ssh/<key_name>.pub
 
-### Manually trusted key Verification Strategy
+#### Manually trusted key Verification Strategy
 
 ![](images/hkvs-trusted-key.png)
 
@@ -133,21 +134,21 @@ this host before the connection will be allowed to be established.
 If this option is not enabled then the key presented on first connection for this host will be automatically trusted
 and allowed for all subsequent connections without any manual intervention.
 
-### Non verifying Verification Strategy
+#### Non verifying Verification Strategy
 
 ![](images/hkvs-no-verify.png)
 
 Does not perform any verification of the SSH key presented by the remote host, allowing all connections regardless of the key they present.
 
-## Availability
+### Availability
 
-### Keep this agent online as much as possible
+#### Keep this agent online as much as possible
 In this mode, Jenkins will keep this agent online as much as possible.
 If the agent goes offline, e.g. due to a temporary network failure, Jenkins will periodically attempt to restart it.
 
 ![](images/availability-as-much.png)
 
-### Take this agent online and offline at specific times
+#### Take this agent online and offline at specific times
 In this mode, Jenkins will bring this agent online at the scheduled time(s), remaining online for a specified amount of time.
 If the agent goes offline while it is scheduled to be online, Jenkins will periodically attempt to restart it.
 
@@ -157,7 +158,7 @@ Jenkins will wait for any any builds that may be in progress to complete.
 
 ![](images/availability-schedule.png)
 
-### Take this agent online when in demand, and offline when idle
+#### Take this agent online when in demand, and offline when idle
 In this mode, Jenkins will bring this agent online if there is demand, i.e. there are queued builds which meet the following criteria:
 * They have been in the queue for at least the specified *In demand delay time period*
 * They can be executed by this agent (e.g. have a matching label expression)
@@ -168,9 +169,9 @@ This agent will be taken offline if:
 
 ![](images/availability-on-demand.png)
 
-## Integration with SSH Credentials Plugin
+### Integration with SSH Credentials Plugin
 This plugin is now integrated with the [SSH Credentials Plugin](https://plugins.jenkins.io/ssh-credentials). 
-This changes how slaves are configured.
+This changes how agents are configured.
 The Node configuration is simplified, e.g. you now just have a Credentials drop down listing all the "Global" and 
 "System" scoped credentials.
  
@@ -179,11 +180,11 @@ If you are upgrading from a previous 0.23 version, the plugin should try to inje
 
 ![](images/ssh-credentials-select.png)
 
-To define credentials to use when connecting slaves you need to go to the `Jenkins/Manage Jenkins/Manage Credentials` screen 
+To define credentials to use when connecting agents you need to go to the `Jenkins/Manage Jenkins/Manage Credentials` screen.
 
 ![](images/ssh-credentials-manage.png)
 
-Once on this screen you can add **SSH credentials**, either using a *Username & Password* or using a *Username & Private Key* 
+Once on this screen you can add **SSH credentials**, either using a *Username & Password* or using a *Username & Private Key*.
 
 ![](images/ssh-credentials-manage-detail.png)
 
@@ -200,12 +201,12 @@ and the specified hostname and port, so where you have created the appropriate c
 will be restricted to those outside of any credential domain and those from matching credential domains.
 This can help differentiate between multiple keys/password associated with the same username.
 
-## Using Cygwin
-See [SSH slaves and Cygwin](https://wiki.jenkins.io/display/JENKINS/SSH+slaves+and+Cygwin) for the discussion of how to use this plugin to talk to Cygwin SSHD server.
+### Using Cygwin
+See [SSH Build Agents and Cygwin](https://wiki.jenkins.io/display/JENKINS/SSH+slaves+and+Cygwin) for the discussion of how to use this plugin to talk to Cygwin SSHD server.
 
 [Remoting documentation](https://github.com/jenkinsci/remoting/tree/master/docs)
 
-## launch Windows slaves using Microsoft OpenSSH
+### Launch Windows agents using Microsoft OpenSSH
 
 The current version of the plugin does not run directly on PowerShell, you have to use prefix and suffix settings to trick the command and make it works, Windows 10 machines can run as SSH agents with the Microsoft OpenSSH server by using:
 

--- a/src/main/java/hudson/plugins/sshslaves/PluginImpl.java
+++ b/src/main/java/hudson/plugins/sshslaves/PluginImpl.java
@@ -32,7 +32,7 @@ import com.trilead.ssh2.Connection;
 import hudson.Plugin;
 
 /**
- * Entry point of ssh-slaves plugin.
+ * Entry point of the plugin.
  *
  * @author Stephen Connolly
  */
@@ -48,7 +48,7 @@ public class PluginImpl extends Plugin {
      */
     @Override
     public void start() throws Exception {
-        LOGGER.log(Level.FINE, "Starting SSH Slaves plugin");
+        LOGGER.log(Level.FINE, "Starting the SSH Build Agents plugin");
     }
 
     /**
@@ -56,9 +56,9 @@ public class PluginImpl extends Plugin {
      */
     @Override
     public void stop() throws Exception {
-        LOGGER.log(Level.FINE, "Stopping SSH Slaves plugin.");
+        LOGGER.log(Level.FINE, "Stopping the SSH Build Agents plugin.");
         closeRegisteredConnections();
-        LOGGER.log(Level.FINE, "SSH Slaves plugin stopped.");
+        LOGGER.log(Level.FINE, "SSH Build Agents plugin stopped.");
     }
 
     /**

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -379,7 +379,7 @@ public class SSHLauncher extends ComputerLauncher {
     /**
      * Returns the remote root workspace (without trailing slash).
      *
-     * @param computer The slave computer to get the root workspace of.
+     * @param computer The computer to get the root workspace of.
      *
      * @return the remote root workspace (without trailing slash).
      *
@@ -979,16 +979,16 @@ public class SSHLauncher extends ComputerLauncher {
 
         Integer exitCode = session.getExitStatus();
         if (exitCode != null)
-            return "Slave JVM has terminated. Exit code=" + exitCode;
+            return "Agent JVM has terminated. Exit code=" + exitCode;
 
         String sig = session.getExitSignal();
         if (sig != null)
-            return "Slave JVM has terminated. Exit signal=" + sig;
+            return "Agent JVM has terminated. Exit signal=" + sig;
 
         if (isConnectionLost)
-            return "Slave JVM has not reported exit code before the socket was lost";
+            return "Agent JVM has not reported exit code before the socket was lost";
 
-        return "Slave JVM has not reported exit code. Is it still running?";
+        return "Agent JVM has not reported exit code. Is it still running?";
     }
 
     public String getCredentialsId() {

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor.java
@@ -33,7 +33,7 @@ import hudson.slaves.SlaveComputer;
 import jenkins.model.Jenkins;
 
 /**
- * An administrative warning that checks all SSH slaves have a {@link SshHostKeyVerificationStrategy}
+ * An administrative warning that checks all SSH build agents have a {@link SshHostKeyVerificationStrategy}
  * set against them and prompts the admin to update the settings as needed.
  * @author Michael Clarke
  * @since 1.13

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -172,14 +172,14 @@ public class SSHLauncherTest {
     SSHLauncher launcher = new SSHLauncher(host, 123, "dummyCredentialId");
     launcher.setSshHostKeyVerificationStrategy(new KnownHostsFileKeyVerificationStrategy());
     assertEquals(host.trim(), launcher.getHost());
-    DumbSlave slave = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
-    j.jenkins.addNode(slave);
+    DumbSlave agent = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
+    j.jenkins.addNode(agent);
 
-    HtmlPage p = j.createWebClient().getPage(slave, "configure");
+    HtmlPage p = j.createWebClient().getPage(agent, "configure");
     j.submit(p.getFormByName("config"));
     Slave n = (Slave) j.jenkins.getNode("agent");
 
-    assertNotSame(n, slave);
+    assertNotSame(n, agent);
     assertNotSame(n.getLauncher(), launcher);
     j.assertEqualDataBoundBeans(n.getLauncher(), launcher);
   }
@@ -225,13 +225,13 @@ public class SSHLauncherTest {
       )
     );
     SSHLauncher launcher = new SSHLauncher("localhost", 123, "dummyCredentialId");
-    DumbSlave slave = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
+    DumbSlave agent = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
 
     Fingerprint fingerprint = CredentialsProvider.getFingerprintOf(credentials);
     assertThat("No fingerprint created until use", fingerprint, nullValue());
 
-    j.jenkins.addNode(slave);
-    while (slave.toComputer().isConnecting()) {
+    j.jenkins.addNode(agent);
+    while (agent.toComputer().isConnecting()) {
       // Make sure verification takes place after launch is complete
       Thread.sleep(100);
     }
@@ -250,13 +250,13 @@ public class SSHLauncherTest {
       )
     );
     SSHLauncher launcher = new SSHLauncher("localhost", 123, "dummyCredentialId");
-    DumbSlave slave = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
+    DumbSlave agent = new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
 
     Fingerprint fingerprint = CredentialsProvider.getFingerprintOf(credentials);
     assertThat("No fingerprint created until use", fingerprint, nullValue());
 
-    j.jenkins.addNode(slave);
-    while (slave.toComputer().isConnecting()) {
+    j.jenkins.addNode(agent);
+    while (agent.toComputer().isConnecting()) {
       // Make sure verification takes place after launch is complete
       Thread.sleep(100);
     }
@@ -301,9 +301,9 @@ public class SSHLauncherTest {
     String javaHomeTool = "/java_home_tool";
 
     SSHLauncher sshLauncher = new SSHLauncher("Hostname", 22, "credentialID");
-    DumbSlave slave = new DumbSlave("agent" + j.jenkins.getNodes().size(), "/home/test/agent", sshLauncher);
-    j.jenkins.addNode(slave);
-    SlaveComputer computer = slave.getComputer();
+    DumbSlave agent = new DumbSlave("agent" + j.jenkins.getNodes().size(), "/home/test/agent", sshLauncher);
+    j.jenkins.addNode(agent);
+    SlaveComputer computer = agent.getComputer();
 
     List<EnvironmentVariablesNodeProperty.Entry> env = new ArrayList<>();
     EnvironmentVariablesNodeProperty.Entry entry = new EnvironmentVariablesNodeProperty.Entry(DefaultJavaProvider.JAVA_HOME, javaHome);
@@ -404,10 +404,10 @@ public class SSHLauncherTest {
 
   @Test
   public void retryTest() throws IOException, InterruptedException, Descriptor.FormException {
-    DumbSlave slave = getDumbSlaveHostNotExist();
-    j.jenkins.addNode(slave);
+    DumbSlave agent = getPermanentAgentHostNotExist();
+    j.jenkins.addNode(agent);
     Thread.sleep(25000);
-    String log = slave.getComputer().getLog();
+    String log = agent.getComputer().getLog();
 
     assertTrue(log.contains("There are 3 more retries left."));
     assertTrue(log.contains("There are 2 more retries left."));
@@ -415,14 +415,14 @@ public class SSHLauncherTest {
     assertFalse(log.contains("There are 4 more retries left."));
   }
 
-  private DumbSlave getDumbSlaveHostNotExist() throws Descriptor.FormException, IOException {
+  private DumbSlave getPermanentAgentHostNotExist() throws Descriptor.FormException, IOException {
     fakeCredentials("dummyCredentialId");
     final SSHLauncher launcher = new SSHLauncher("HostNotExists", 22, "dummyCredentialId");
     launcher.setSshHostKeyVerificationStrategy(new NonVerifyingKeyVerificationStrategy());
     launcher.setLaunchTimeoutSeconds(5);
     launcher.setRetryWaitTime(1);
     launcher.setMaxNumRetries(3);
-    return new DumbSlave("slave", j.createTmpDir().getPath(), launcher);
+    return new DumbSlave("agent", j.createTmpDir().getPath(), launcher);
   }
 
   private void fakeCredentials(String id) {

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyActionTest.java
@@ -106,16 +106,17 @@ public class TrustHostKeyActionTest {
         }
 
         SSHLauncher launcher = new SSHLauncher("localhost", port, "dummyCredentialId", null, "xyz", null, null, 30, 1, 1, new ManuallyTrustedKeyVerificationStrategy(true));
-        DumbSlave slave = new DumbSlave("test-agent", "SSH Test agent",
+        DumbSlave agent = new DumbSlave("test-agent", "SSH Test agent",
                 temporaryFolder.newFolder().getAbsolutePath(), "1", Mode.NORMAL, "",
                 launcher, RetentionStrategy.NOOP, Collections.emptyList());
         
-        jenkins.getInstance().addNode(slave);
+        jenkins.getInstance().addNode(agent);
         SlaveComputer computer = (SlaveComputer) jenkins.getInstance().getComputer("test-agent");
 
         try {
             computer.connect(false).get();
         } catch (ExecutionException ex){
+            //TODO(oleg_nenashev): "Slave" check is still needed for PCT purposes, but it should be eventually cleaned up 
             if (!ex.getMessage().startsWith("java.io.IOException: Slave failed") && !ex.getMessage().startsWith("java.io.IOException: Agent failed")) {
                 throw ex;
             }
@@ -125,7 +126,7 @@ public class TrustHostKeyActionTest {
         assertEquals(computer.getLog(), 1, actions.size());
         assertNull(actions.get(0).getExistingHostKey());
         
-        HtmlPage p = jenkins.createWebClient().getPage(slave, actions.get(0).getUrlName());
+        HtmlPage p = jenkins.createWebClient().getPage(agent, actions.get(0).getUrlName());
         p.getElementByName("Yes").click();
         
         assertTrue(actions.get(0).isComplete());


### PR DESCRIPTION
See [JENKINS-42840](https://issues.jenkins-ci.org/browse/JENKINS-42840). There were some leftovers after https://github.com/jenkinsci/ssh-slaves-plugin/pull/96

This PR cleans up documentation and Javadoc + some tests while I was around

### Submitter checklist

- [x] JIRA issue is well described
- [x] Appropriate autotests or explanation to why this change has no tests

