### PR TITLE
Bump jcasc version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.50</version>
+    <version>3.55</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>
@@ -29,7 +29,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.190.1</jenkins.version>
     <java.level>8</java.level>
-    <configuration-as-code.version>1.30</configuration-as-code.version>
+    <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>
 
   <developers>
@@ -167,6 +167,11 @@
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+
       </exclusions>
     </dependency>
     <dependency>
@@ -176,10 +181,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
       <version>${configuration-as-code.version}</version>
-      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a `tests` classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
https://github.com/jenkinsci/bom/pull/164