### PR TITLE
[1.30.x] Bump jcasc version (#173)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.45</version>
+    <version>3.55</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>
@@ -29,7 +29,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.150.1</jenkins.version>
     <java.level>8</java.level>
-    <configuration-as-code.version>1.30</configuration-as-code.version>
+    <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>
 
   <developers>
@@ -125,6 +125,11 @@
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+
       </exclusions>
     </dependency>
     <dependency>
@@ -134,10 +139,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
       <version>${configuration-as-code.version}</version>
-      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Backports the following commits to 1.30.x:
 - Bump jcasc version  (#173)