### PR TITLE
Demonstrate adding findsecbugs to spotbugs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-  
+
   <dependencies>
     <!-- plugin dependencies -->
 
@@ -196,6 +196,19 @@
         <configuration>
           <minimumJavaVersion>1.8</minimumJavaVersion>
           <compatibleSinceVersion>1.31.0</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.10.1</version>
+            </plugin>
+          </plugins>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -679,8 +679,8 @@ public class SSHLauncher extends ComputerLauncher {
                 // If the agent jar already exists see if it needs to be updated
                 boolean overwrite = true;
                 if (sftpClient.exists(fileName)) {
-                    String sourceAgentHash = getMd5Hash(agentJar);
-                    String existingAgentHash = getMd5Hash(readInputStreamIntoByteArrayAndClose(sftpClient.read(fileName)));
+                    String sourceAgentHash = computeHash(agentJar);
+                    String existingAgentHash = computeHash(readInputStreamIntoByteArrayAndClose(sftpClient.read(fileName)));
                     listener.getLogger().println(MessageFormat.format( "Source agent hash is {0}. "
                       + "Installed agent hash is {1}", sourceAgentHash, existingAgentHash));
 
@@ -735,11 +735,11 @@ public class SSHLauncher extends ComputerLauncher {
      * @return
      * @throws NoSuchAlgorithmException
      */
-    static String getMd5Hash(byte[] bytes) throws NoSuchAlgorithmException {
+    static String computeHash(byte[] bytes) throws NoSuchAlgorithmException {
 
         String hash;
         try {
-            MessageDigest md = MessageDigest.getInstance("MD5");
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
             md.update(bytes);
             byte[] digest = md.digest();
 

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/HostKeyHelper.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/HostKeyHelper.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.XmlFile;
 import hudson.model.Computer;
 import hudson.model.Node;
@@ -96,7 +97,8 @@ public final class HostKeyHelper {
     private File getSshHostKeyFile(Node node) throws IOException {
         return new File(getNodeDirectory(node), "ssh-host-key.xml");
     }
-    
+
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Path is built from configuration values.")
     private File getNodeDirectory(Node node) throws IOException {
         if (null == node) {
             throw new IOException("Could not load key for the requested node");

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy.java
@@ -24,6 +24,7 @@
 package hudson.plugins.sshslaves.verifiers;
 
 import com.trilead.ssh2.KnownHosts;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import hudson.plugins.sshslaves.Messages;
@@ -45,6 +46,7 @@ import java.nio.file.Paths;
  * @author Michael Clarke
  * @since 1.13
  */
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Path is built from configuration values.")
 public class KnownHostsFileKeyVerificationStrategy extends SshHostKeyVerificationStrategy {
 
   public static final String KNOWN_HOSTS_DEFAULT = Paths.get(System.getProperty("user.home"), ".ssh", "known_hosts").toString();

--- a/src/main/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyAction.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/TrustHostKeyAction.java
@@ -90,6 +90,7 @@ public class TrustHostKeyAction extends TaskAction  {
         response.sendRedirect("../");
     }
 
+    @SuppressFBWarnings(value = "REQUESTDISPATCHER_FILE_DISCLOSURE", justification = "This forwards to a fixed path for approving the host key.")
     public void doIndex(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         req.getView(this, "trustHostKey").forward(req, rsp);
     }

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,8 @@
+<FindBugsFilter>
+
+    <Match>
+    <!--We don't care about this behavior.-->
+    <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
+  </Match>
+
+</FindBugsFilter>

--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -372,8 +372,8 @@ public class SSHLauncherTest {
 
     try {
       byte[] bytes = "Leave me alone!".getBytes();
-      String result = SSHLauncher.getMd5Hash(bytes);
-      assertTrue("1EB226C8E950BAC1494BE197E84A264C".equals(result));
+      String result = SSHLauncher.computeHash(bytes);
+      assertTrue("84F44B884A53CD4BA631539EB0538A48ECD7A8F666DC5584B7644F8ACE9BF086".equals(result));
     } catch (Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
Demonstrate adding findsecbugs to spotbugs. This commit is a demonstration and is not intended to be merged as-is.

Findsecbugs reports several findings for this plugin, but all of them can be safely suppressed or reworked. There are a few that could be a concern, but examination shows that as currently used they do not introduce a vulnerability. The MD5 hash is not stored so it can be easily converted to a more reliable algorithm.

This also uses the exclude file for a couple of finding types that are fairly common in Jenkins but not considered a concern.

---

My plan is to add findsecbugs at the plugin pom after sufficient testing and communication. At that point, it would make sense to add the suppressions, but not the pom file changes from this PR.