### PR TITLE
Improved buildConfiguration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,9 @@
 //def buildConfiguration = buildPlugin.recommendedConfigurations()
 
 def buildConfiguration = [
-  [ platform: "linux",   jdk: "8", jenkins: "2.190.1", javaLevel: "8" ],
-  [ platform: "windows", jdk: "8", jenkins: "2.190.1", javaLevel: "8" ],
-  [ platform: "linux",   jdk: "11", jenkins: "2.190.1", javaLevel: "8" ],
-  [ platform: "windows", jdk: "11", jenkins: "2.190.1", javaLevel: "8" ],
-  // Also build on recent weekly
-  [ platform: "linux",   jdk: "11", jenkins: "2.197", javaLevel: "8" ],
-  [ platform: "windows", jdk: "11", jenkins: "2.197", javaLevel: "8" ]
+  [platform: 'linux',   jdk: '8'],
+  [platform: 'windows', jdk: '8'],
+  [platform: 'linux',   jdk: '11', jenkins: '2.222.1'],
 ]
 
 buildPlugin(configurations: buildConfiguration)


### PR DESCRIPTION
I noticed that #178 was not publishing binaries due to https://github.com/jenkins-infra/pipeline-library/blob/c7acbe5bf68da0f1ad00d63d40a38e9dc59d6e6d/vars/buildPlugin.groovy#L58. While I am here, cleaning up a bit and aligning with https://github.com/jenkins-infra/pipeline-library/pull/120.