### PR TITLE
Fix issue with Java installed into a path with spaces

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
+++ b/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
@@ -88,11 +88,7 @@ public class JavaVersionChecker {
         StringWriter output = new StringWriter();   // record output from Java
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        // if the command has a space, we need to quote it
-        if(javaCommand.contains(" ")) {
-            javaCommand = "\"" + javaCommand + "\"";
-        }
-        connection.exec(javaCommand + " "+ jvmOptions + " -version",out);
+        connection.exec("\"" + javaCommand + "\" "+ jvmOptions + " -version",out);
         //TODO: Seems we need to retrieve the encoding from the connection destination
         BufferedReader r = new BufferedReader(new InputStreamReader(
                 new ByteArrayInputStream(out.toByteArray()), Charset.defaultCharset()));

--- a/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
+++ b/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
@@ -88,6 +88,10 @@ public class JavaVersionChecker {
         StringWriter output = new StringWriter();   // record output from Java
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
+        // if the command has a space, we need to quote it
+        if(javaCommand.contains(" ")) {
+            javaCommand = "\"" + javaCommand + "\"";
+        }
         connection.exec(javaCommand + " "+ jvmOptions + " -version",out);
         //TODO: Seems we need to retrieve the encoding from the connection destination
         BufferedReader r = new BufferedReader(new InputStreamReader(


### PR DESCRIPTION
This can happen on Windows most often with the existing installers (AdoptOpenJDK, Oracle JDK, etc).

I don't think this needs tests, but would be happy to look into it if maintainers think otherwise.

### Submitter checklist

- [X] Appropriate autotests or explanation to why this change has no tests

