### PR TITLE
chore: use BOM to manage the Jenkins Core dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.55</version>
+    <version>4.13</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>
@@ -27,7 +27,7 @@
   <properties>
     <revision>1.31.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.204</jenkins.version>
+    <jenkins.version>2.204.4</jenkins.version>
     <java.level>8</java.level>
     <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>
@@ -90,6 +90,7 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
+
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
@@ -99,6 +100,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.204.x</artifactId>
+        <version>17</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!--
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
@@ -119,12 +128,13 @@
         <artifactId>slf4j-jdk14</artifactId>
         <version>1.7.26</version>
       </dependency>
+      -->
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
     <!-- plugin dependencies -->
-
+<!--
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -141,7 +151,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
     </dependency>
-
+-->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,51 +107,10 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!--
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>1.7.26</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>1.7.26</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>log4j-over-slf4j</artifactId>
-        <version>1.7.26</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-jdk14</artifactId>
-        <version>1.7.26</version>
-      </dependency>
-      -->
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
-    <!-- plugin dependencies -->
-<!--
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-    </dependency>
--->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
@@ -174,14 +133,9 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
-
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Change to use BOM introduces in the latest `org.jenkins-ci.plugins:plugi:4.x`
