### PR TITLE
[JENKINS-64404] Additional fix for Java installed into a path with spaces

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
+++ b/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
@@ -88,7 +88,9 @@ public class JavaVersionChecker {
         StringWriter output = new StringWriter();   // record output from Java
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        connection.exec("\"" + javaCommand + "\" "+ jvmOptions + " -version",out);
+        //Always quoted java command in order to handle spaces in java path
+        javaCommand = "\"" + javaCommand + "\"";
+        connection.exec(javaCommand + " "+ jvmOptions + " -version",out);
         //TODO: Seems we need to retrieve the encoding from the connection destination
         BufferedReader r = new BufferedReader(new InputStreamReader(
                 new ByteArrayInputStream(out.toByteArray()), Charset.defaultCharset()));


### PR DESCRIPTION
Those changes complete :
commit 9646cef228485f3bdf2cbec34b0dc7d0f3fa3d0e
Fix issue with Java installed into a path with spaces (#183)

See [JENKINS-64404](https://issues.jenkins-ci.org/browse/JENKINS-64404).


### Submitter checklist

- [ x ] JIRA issue is well described
- [ x ] Appropriate autotests or explanation to why this change has no tests ( PR build validate on our preprod server)

