### PR TITLE
Add /opt/java/openjdk as a potential Java source for jenkins/ssh-agent AdoptOpenJDK Alpine images

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/DefaultJavaProvider.java
+++ b/src/main/java/hudson/plugins/sshslaves/DefaultJavaProvider.java
@@ -82,7 +82,7 @@ public class DefaultJavaProvider extends JavaProvider {
                                    "/usr/java/latest/bin/java",
                                    "/usr/local/bin/java",
                                    "/usr/local/java/bin/java",
-                                   "/opt/java/openjdk"));
+                                   "/opt/java/openjdk/bin/java"));
         return javas;
     }
 

--- a/src/main/java/hudson/plugins/sshslaves/DefaultJavaProvider.java
+++ b/src/main/java/hudson/plugins/sshslaves/DefaultJavaProvider.java
@@ -81,7 +81,8 @@ public class DefaultJavaProvider extends JavaProvider {
                                    "/usr/java/default/bin/java",
                                    "/usr/java/latest/bin/java",
                                    "/usr/local/bin/java",
-                                   "/usr/local/java/bin/java"));
+                                   "/usr/local/java/bin/java",
+                                   "/opt/java/openjdk"));
         return javas;
     }
 


### PR DESCRIPTION
Jus a minor tweak which helps the instance to discover Java when using the new AdoptOpenJDK packages for alpine. https://github.com/jenkinsci/docker-ssh-agent/blob/master/8/alpine/Dockerfile 

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

