### PR TITLE
[JENKINS-65155] The "java is not in the path" warning is show even though java is in the path

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
+++ b/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
@@ -76,11 +76,6 @@ public class JavaVersionChecker {
                 try {
                     return checkJavaVersion(listener, javaCommand);
                 } catch (IOException e) {
-                    if(!"java".equalsIgnoreCase(javaCommand)){
-                      LOGGER.log(WARNING, "Java is not in the PATH nor configured with the javaPath setting,"
-                                          + " Jenkins will try to guess where is Java,"
-                                          + "this guess will be remove in the future.");
-                    }
                     LOGGER.log(FINE, "Failed to check the Java version",e);
                     // try the next one
                 }

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -525,7 +525,7 @@ public class SSHLauncher extends ComputerLauncher {
    */
   private void checkJavaIsInPath(TaskListener listener) {
     String msg = "Java is not in the PATH nor configured with the javaPath setting,"
-                 + " Jenkins will try to guess where is Java,"
+                 + " Jenkins will try to guess where is Java, "
                  + "this guess will be removed in the future. :"
                  + getDescriptor().getDisplayName();
     int ret = 0;

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -526,7 +526,7 @@ public class SSHLauncher extends ComputerLauncher {
   private void checkJavaIsInPath(TaskListener listener) {
     String msg = "Java is not in the PATH nor configured with the javaPath setting,"
                  + " Jenkins will try to guess where is Java,"
-                 + "this guess will be remove in the future. :"
+                 + "this guess will be removed in the future. :"
                  + getDescriptor().getDisplayName();
     int ret = 0;
     try {


### PR DESCRIPTION

See [JENKINS-65155](https://issues.jenkins-ci.org/browse/JENKINS-65155).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

