### PR TITLE
improve error message for Java missing on agent

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
+++ b/src/main/java/hudson/plugins/sshslaves/JavaVersionChecker.java
@@ -81,7 +81,7 @@ public class JavaVersionChecker {
                 }
             }
         }
-        throw new IOException("Java not found on " + computer + ". Install a Java 8 version on the Agent.");
+        throw new IOException("Java not found on " + computer + ". Install Java 8 or Java 11 on the Agent.");
     }
 
     @NonNull


### PR DESCRIPTION
This PR improves the error message to cover SSH agents running Java 11.

In my case, this error message was caused by this issue: https://github.com/jenkinsci/docker-ssh-agent/issues/33

I have not tested this PR.

Thanks!

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests