### PR TITLE
Replace usages of `com.google.common.io.ByteStreams` with usages of `org.apache.commons.io.IOUtils`

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -30,7 +30,6 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.HostnamePortRequirement;
 import com.cloudbees.plugins.credentials.domains.SchemeRequirement;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
-import com.google.common.io.ByteStreams;
 import com.trilead.ssh2.ChannelCondition;
 import com.trilead.ssh2.Connection;
 import com.trilead.ssh2.SCPClient;
@@ -794,7 +793,7 @@ public class SSHLauncher extends ComputerLauncher {
 
         byte[] bytes = null;
         try{
-            bytes = ByteStreams.toByteArray(inputStream);
+            bytes = IOUtils.toByteArray(inputStream);
         }catch(IOException e){
             throw e;
         } finally {


### PR DESCRIPTION
This plugin consumes both Apache Commons IO and Guava, which seems redundant. One of the two can be dropped, so in this PR I'm dropping the dependency on Guava. Having fewer dependencies makes maintaining this plugin easier, and not depending on Guava means this plugin doesn't have to worry about any risk if/when Guava is upgraded in Jenkins core.