### PR TITLE
[JENKINS-65929] Improve docker detection by relying on `docker ps`

### DIFF
--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentConnectionBase.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentConnectionBase.java
@@ -41,7 +41,7 @@ public class AgentConnectionBase {
   @Rule
   public CheckIsLinuxOrMac isLinuxOrMac = new CheckIsLinuxOrMac();
 
-  @Rule
+  @Rule(order = -2) // Before JenkinsRule
   public CheckIsDockerAvailable isDockerAvailable = new CheckIsDockerAvailable();
 
   @Rule

--- a/src/test/java/hudson/plugins/sshslaves/rules/CheckIsDockerAvailable.java
+++ b/src/test/java/hudson/plugins/sshslaves/rules/CheckIsDockerAvailable.java
@@ -18,13 +18,13 @@ public class CheckIsDockerAvailable extends ExternalResource {
   }
 
   boolean isDockerAvailable() {
-    int exitCode = 0;
+    int exitCode;
     try {
       ProcessBuilder builder = new ProcessBuilder();
       if (SystemUtils.IS_OS_WINDOWS) {
-        builder.command("cmd.exe", "/c", "docker --version");
+        builder.command("cmd.exe", "/c", "docker ps");
       } else {
-        builder.command("sh", "-c", "docker --version");
+        builder.command("sh", "-c", "docker ps");
       }
       Process process = builder.start();
       exitCode = process.waitFor();


### PR DESCRIPTION
`docker --version` only checks for docker client availability but not for
the presence of a docker daemon.

Also reorder rules so that the docker check happens before starting
Jenkins

See [JENKINS-65929](https://issues.jenkins-ci.org/browse/JENKINS-65929).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

