### PR TITLE
fix: ignore EI_EXPOSE_REP2 spotbugs warning

### DIFF
--- a/spotbugs-exclude-filter.xml
+++ b/spotbugs-exclude-filter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<FindBugsFilter>
+  <Match>
+    <Or>
+      <Class name="~.*JavaVersionChecker.*$" />
+      <Class name="~.*SSHLauncher.*$" />
+    </Or>
+    <Bug pattern="EI_EXPOSE_REP2" />
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
Spotbug is reporting 3 warnings (EI_EXPOSE_REP2) on Java 8 but not in Java 11, let's ignore them for the moment.
