### PR TITLE
chore: bump Jenkins core to 1.289.1 LTS version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <revision>1.32.1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.282</jenkins.version>
+    <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
     <hpi.compatibleSinceVersion>1.31.0</hpi.compatibleSinceVersion>
   </properties>


### PR DESCRIPTION
Bump Jenkins core to nearest LTS

