### PR TITLE
[JENKINS-66601] host key allows ed25519 & ecdsa

### DIFF
--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -116,7 +116,7 @@ potentially using the ssh hostname command to initiate a connection and update t
 Checks the key provided by the remote host matches the key set by the user who configured this connection.
 
 The SSH key expected for this connection. This key should be in the form `algorithm value`
-where algorithm is one of ssh-rsa or ssh-dss, and value is the Base 64 encoded content of the key. The keys should be placed in /etc/ssh/<key_name>.pub
+where `algorithm` is one of ssh-rsa, ssh-ed25519, or ecdsa-sha2-nistp256, and `value` is the base 64 encoded content of the key. The public keys for a Linux agent can be read from the agent file system at `/etc/ssh/<key_name>.pub`.
 
 #### Manually trusted key Verification Strategy
 


### PR DESCRIPTION
## [JENKINS-66601](https://issues.jenkins-ci.org/browse/JENKINS-66601) - Host key allows ED-25519 and ECDSA

Add ED-25519 and ECDSA as allowed host key algorithms.

Remove DSS because the DSA algorithm has been removed from OpenSSH. See https://security.stackexchange.com/questions/112802/why-openssh-deprecated-dsa-keys for the description of the removal of DSA/DSS.

Documentation change only.  No automated tests.

I've confirmed from my use of the current release of the plugin that ED-25519 and ECDSA public keys are allowed as the host key.

I've confirmed that the ssh-dss public host keys from my FreeNAS 12.1 host and from my OpenBSD 6.9 host are rejected by the current release of the plugin when running from the `jenkins/jenkins:2.303.1` Docker image.  The dialog box accepts the host key but the agent connection fails and the log reports that the host key is not recognized.   Recent Linux hosts seem to no longer offer a DSA host key.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Appropriate autotests or explanation to why this change has no tests

