### PR TITLE
fixup System.out.println to listener.getLogger().println

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -493,16 +493,16 @@ public class SSHLauncher extends ComputerLauncher {
                     listener.getLogger().println(Messages.SSHLauncher_launchCanceled());
                 }
                 if (!res) {
-                    System.out.println(Messages.SSHLauncher_LaunchFailedDuration(getTimestamp(),
+                    listener.getLogger().println(Messages.SSHLauncher_LaunchFailedDuration(getTimestamp(),
                             nodeName, host, duration));
                     listener.getLogger().println(getTimestamp() + " Launch failed - cleaning up connection");
                     cleanupConnection(listener);
                 } else {
-                    System.out.println(Messages.SSHLauncher_LaunchCompletedDuration(getTimestamp(),
+                    listener.getLogger().println(Messages.SSHLauncher_LaunchCompletedDuration(getTimestamp(),
                             nodeName, host, duration));
                 }
             } catch (InterruptedException e) {
-                System.out.println(Messages.SSHLauncher_LaunchFailed(getTimestamp(),
+                listener.getLogger().println(Messages.SSHLauncher_LaunchFailed(getTimestamp(),
                         nodeName, host));
             } finally {
                 ExecutorService srv = launcherExecutorService;


### PR DESCRIPTION
fixup System.out.println to listener.getLogger().println

same as in file src/main/java/hudson/plugins/sshslaves/SSHLauncher.java line 493, print the messages to listener.getLogger()
https://github.com/jenkinsci/ssh-slaves-plugin/blob/main/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java#L493

I think replace System.out.println to listener.getLogger()  is better.

or maybe  replace System.out.println to  Logger LOGGER = Logger.getLogger(SSHLauncher.class.getName()); 
The System.out output messages are sent to the Jenkins logs maybe use LOGGER is best way.



Signed-off-by: bright.ma rmsh06 <bright.ma@blackshark.com>

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

