### PR TITLE
Changes monitor category

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/MissingVerificationStrategyAdministrativeMonitor.java
@@ -65,6 +65,11 @@ public class MissingVerificationStrategyAdministrativeMonitor extends Administra
     }
 
     public String getAgentNames() {
-      return agentNames != null ? agentNames.toString() : "";
+        return agentNames != null ? agentNames.toString() : "";
+    }
+
+    @Override
+    public boolean isSecurity() {
+        return true;
     }
 }


### PR DESCRIPTION
Since Jenkins 2.267, there are 2 different category of monitors: security and non security ones.
In this plugin, the administrative monitor is enabled when an agent is connected using SSH keys but no key validation strategy is enabled is the connection configuration.
As this could lead to issues with those agent, it would be preferable that this monitor to be considered as a security one.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

