### PR TITLE
chore: test most common SSH connections

### DIFF
--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentDSAConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentDSAConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKeyAuthenticationTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKeyAuthenticationTest.class})
 public class AgentDSAConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-dsa";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentECDHSha2Nistp256ConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentECDHSha2Nistp256ConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKexTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKexTest.class})
 public class AgentECDHSha2Nistp256ConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-ecdh-sha2-nistp256";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentECDHSha2Nistp384ConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentECDHSha2Nistp384ConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKexTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKexTest.class})
 public class AgentECDHSha2Nistp384ConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-ecdh-sha2-nistp384";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA256ConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA256ConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKeyAuthenticationTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKeyAuthenticationTest.class})
 public class AgentRSA256ConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-rsa256";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA_AES128CBC_ConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA_AES128CBC_ConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKeyAuthenticationTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKeyAuthenticationTest.class})
 public class AgentRSA_AES128CBC_ConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-rsa";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA_AES192CBC_ConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA_AES192CBC_ConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKeyAuthenticationTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKeyAuthenticationTest.class})
 public class AgentRSA_AES192CBC_ConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-rsa";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA_DESCBC_ConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA_DESCBC_ConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKeyAuthenticationTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKeyAuthenticationTest.class})
 public class AgentRSA_DESCBC_ConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-rsa";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA_DES_EDE3CBC_ConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentRSA_DES_EDE3CBC_ConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKeyAuthenticationTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKeyAuthenticationTest.class})
 public class AgentRSA_DES_EDE3CBC_ConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-rsa";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentUbuntu1404RSAConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentUbuntu1404RSAConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKeyAuthenticationTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKeyAuthenticationTest.class})
 public class AgentUbuntu1404RSAConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-ubuntu-14.04";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentUbuntu1604RSAConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentUbuntu1604RSAConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKeyAuthenticationTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKeyAuthenticationTest.class})
 public class AgentUbuntu1604RSAConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-ubuntu-16.04";

--- a/src/test/java/hudson/plugins/sshslaves/agents/AgentUbuntu1804RSAConnectionTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/agents/AgentUbuntu1804RSAConnectionTest.java
@@ -11,12 +11,14 @@ import hudson.model.Node;
 import hudson.plugins.sshslaves.categories.AgentSSHTest;
 import hudson.plugins.sshslaves.categories.SSHKeyAuthenticationTest;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * Connect to a remote SSH Agent
  *
  * @author Kuisathaverat
  */
+@Ignore("Only for manual test.")
 @Category({ AgentSSHTest.class, SSHKeyAuthenticationTest.class})
 public class AgentUbuntu1804RSAConnectionTest extends AgentConnectionBase {
   public static final String SSH_AGENT_NAME = "ssh-agent-ubuntu-18.04";


### PR DESCRIPTION
Test most common SSH connections, this PR disabled some of the old key formats and test the most common, we will continue having the tests for manual testing. This will reduce the time of the builds.

