### PR TITLE
[JENKINS-68195] Duplicated help icon for Host Key verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 work
 bin
 .DS_Store
+.vscode

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,7 @@
 //def buildConfiguration = buildPlugin.recommendedConfigurations()
 
 def buildConfiguration = [
-  [platform: 'linux',   jdk: '8'],
-  [platform: 'windows', jdk: '8'],
+  [platform: 'windows', jdk: '11'],
   [platform: 'linux',   jdk: '11'],
 ]
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.342</jenkins.version>
+    <jenkins.version>2.346.2</jenkins.version>
     <java.level>8</java.level>
     <hpi.compatibleSinceVersion>1.31.0</hpi.compatibleSinceVersion>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
-        <version>1246.va_b_50630c1d19</version>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1478.v81d3dc4f9a_43</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.342</jenkins.version>
     <java.level>8</java.level>
     <hpi.compatibleSinceVersion>1.31.0</hpi.compatibleSinceVersion>
   </properties>
@@ -102,18 +102,14 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.277.x</artifactId>
-        <version>961.vf0c9f6f59827</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1246.va_b_50630c1d19</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>jackson2-api</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config.jelly
@@ -5,9 +5,7 @@
       <c:select checkMethod="post"/>
   </f:entry>
 
-  <f:entry>
-    <f:dropdownDescriptorSelector field="sshHostKeyVerificationStrategy" title="${%Host Key Verification Strategy}"/>
-  </f:entry>
+  <f:dropdownDescriptorSelector field="sshHostKeyVerificationStrategy" title="${%Host Key Verification Strategy}"/>
 
   <f:advanced>
       <f:entry title="${%Port}" field="port">

--- a/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/SSHConnector/config.jelly
@@ -5,7 +5,9 @@
       <c:select checkMethod="post"/>
   </f:entry>
 
-  <f:dropdownDescriptorSelector title="${%Host Key Verification Strategy}" field="sshHostKeyVerificationStrategy" />
+  <f:entry>
+    <f:dropdownDescriptorSelector field="sshHostKeyVerificationStrategy" title="${%Host Key Verification Strategy}"/>
+  </f:entry>
 
   <f:advanced>
       <f:entry title="${%Port}" field="port">

--- a/src/main/resources/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/verifiers/KnownHostsFileKeyVerificationStrategy/config.jelly
@@ -23,15 +23,4 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-
-	<!-- the enclosing drop down list does not show a changeable help field for each type so we manually show one in its absence -->
-	<j:set var="help" value="${descriptor.helpFile}"/>
-    <j:if test="${help != null}">
-        <tr>
-            <td colspan="3"/>
-            <f:helpLink url="${help}"/>
-        </tr>
-        <f:helpArea/>
-    </j:if>
-    
 </j:jelly>

--- a/src/main/resources/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/verifiers/ManuallyProvidedKeyVerificationStrategy/config.jelly
@@ -23,17 +23,6 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-
-	<!-- the enclosing drop down list does not show a changeable help field for each type so we manually show one in its absence -->
-	<j:set var="help" value="${descriptor.helpFile}"/>
-    <j:if test="${help != null}">
-        <tr>
-            <td colspan="3"/>
-            <f:helpLink url="${help}"/>
-        </tr>
-        <f:helpArea/>
-    </j:if>           
-
 	<f:entry title="${%SSH Key}" field="key">
 		<f:textarea checkMethod="post"/>
 	</f:entry>

--- a/src/main/resources/hudson/plugins/sshslaves/verifiers/ManuallyTrustedKeyVerificationStrategy/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/verifiers/ManuallyTrustedKeyVerificationStrategy/config.jelly
@@ -23,17 +23,6 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-	
-	<!-- the enclosing drop down list does not show a changeable help field for each type so we manually show one in its absence -->
-	<j:set var="help" value="${descriptor.helpFile}"/>
-    <j:if test="${help != null}">
-        <tr>
-            <td colspan="3"/>
-            <f:helpLink url="${help}"/>
-        </tr>
-        <f:helpArea/>
-    </j:if>
-	
 	<f:entry title="${%Require manual verification of initial connection}" field="requireInitialManualTrust">
 		<f:checkbox />
 	</f:entry>

--- a/src/main/resources/hudson/plugins/sshslaves/verifiers/NonVerifyingKeyVerificationStrategy/config.jelly
+++ b/src/main/resources/hudson/plugins/sshslaves/verifiers/NonVerifyingKeyVerificationStrategy/config.jelly
@@ -23,15 +23,4 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-
-	<!-- the enclosing drop down list does not show a changeable help field for each type so we manually show one in its absence -->
-	<j:set var="help" value="${descriptor.helpFile}"/>
-    <j:if test="${help != null}">
-        <tr>
-            <td colspan="3"/>
-            <f:helpLink url="${help}"/>
-        </tr>
-        <f:helpArea/>
-    </j:if>
-    
 </j:jelly>


### PR DESCRIPTION
See [JENKINS-68195](https://issues.jenkins-ci.org/browse/JENKINS-68195).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

After some improvements in the `f:dropdownDescriptorSelector` and the UI present in Jenkins Core 2.242 I need to change a couple of things in some jelly files. I have removed a workaround to show the help link on `f:dropdownDescriptorSelector` and I have to put the `f:dropdownDescriptorSelector` inside an `<f:entry>` to avoid showing the help button in the end of the right side of the browser. This is the visual result of the changes:
Before:
<img width="1865" alt="Screenshot 2022-04-08 at 11 41 18" src="https://user-images.githubusercontent.com/5400788/162410169-f954fcd7-c507-4a23-9c33-c19ed349bc40.png">
After:
<img width="1547" alt="Screenshot 2022-04-08 at 11 17 03" src="https://user-images.githubusercontent.com/5400788/162406682-60bef91d-fe0f-4ae7-9ddd-c8da2f6eab66.png">

Related to https://github.com/jenkinsci/jenkins/pull/5417

## Note
This PR cannot be merged before Jenkins Core 2.42 (or upper version) is released as LTS because it breaks the help links in previous versions.