### PR TITLE
Powershell as shell

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -66,7 +66,6 @@ import hudson.util.NamingThreadFactory;
 import hudson.util.NullStream;
 import java.util.Collections;
 
-import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -659,12 +659,13 @@ public class SSHLauncher extends ComputerLauncher {
                             String workingDirectory) throws IOException {
         session = connection.openSession();
         expandChannelBufferSize(session,listener);
-        String cmd = "cd \"" + workingDirectory + "\" && " + java + " " + getJvmOptions() + " -jar " + AGENT_JAR +
-                     getWorkDirParam(workingDirectory);
-
-        if(isWindows && isPowershell) {
+        String cmd = "command no set"
+        if(isWindows && isPowershell){
             cmd = "try { Push-Location \"" + workingDirectory + "\" ; " + java + " " + getJvmOptions() + " -jar " +
                 AGENT_JAR + getWorkDirParam(workingDirectory) + " } finally { Pop-Location }";
+        } else {
+            cmd = "cd \"" + workingDirectory + "\" && " + java + " " + getJvmOptions() + " -jar " + AGENT_JAR +
+                     getWorkDirParam(workingDirectory);
         }
 
         //This will wrap the cmd with prefix commands and suffix commands if they are set.

--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -65,7 +65,6 @@ import hudson.util.ListBoxModel;
 import hudson.util.NamingThreadFactory;
 import hudson.util.NullStream;
 import java.util.Collections;
-
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;


### PR DESCRIPTION
This allows you to use the ssh-agents-plugin with a Windows system that is running powershell as the default shell (https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows). It interrogates the remove system to find out if it is Windows or Linux and then if Powershell is being used. 

There are currently no tests for this, but I am willing to look into tests if that is desired.