### PR TITLE
Remove deprecated java.level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.346.2</jenkins.version>
-    <java.level>8</java.level>
     <hpi.compatibleSinceVersion>1.31.0</hpi.compatibleSinceVersion>
   </properties>
 


### PR DESCRIPTION
Removes the deprecated [`java.level`](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) from POM.


### Submitter checklist

- [x] JIRA issue is well described
- [x] Appropriate autotests or explanation to why this change has no tests

