### PR TITLE
increase jenkinsrule timeout for flaky tests

### DIFF
--- a/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/SSHLauncherTest.java
@@ -66,6 +66,8 @@ import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.HostnamePortSpecification;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import org.jvnet.hudson.test.recipes.WithTimeout;
+
 import static hudson.plugins.sshslaves.SSHLauncher.JAR_CACHE_DIR;
 import static hudson.plugins.sshslaves.SSHLauncher.JAR_CACHE_PARAM;
 import static hudson.plugins.sshslaves.SSHLauncher.WORK_DIR_PARAM;
@@ -239,6 +241,7 @@ public class SSHLauncherTest {
   }
 
   @Issue("JENKINS-38832")
+  @WithTimeout(600)
   @Test
   public void trackCredentialsWithUsernameAndPassword() throws Exception {
     UsernamePasswordCredentialsImpl credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "dummyCredentialId", null, "user", "pass");
@@ -264,6 +267,7 @@ public class SSHLauncherTest {
   }
 
   @Issue("JENKINS-38832")
+  @WithTimeout(600)
   @Test
   public void trackCredentialsWithUsernameAndPrivateKey() throws Exception {
     BasicSSHUserPrivateKey credentials = new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, "dummyCredentialId", "user", null, "", "desc");


### PR DESCRIPTION
SshLauncherTest#trackCredentialsWithUsernameAndPrivateKey and SshLauncherTest#trackCredentialsWithUsernameAndPassword are flaky.

Tests itself are good, but from time to time they hit JenkinsRule's timeout (180 sec), so I suggest to increase timeout to 600 sec as some of tests in other plugin do [(search)](https://github.com/search?q=org%3Ajenkinsci+WithTimeout+600&type=code)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

