### PR TITLE
Update to Jenkins 2.375 LTS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.51</version>
+    <version>4.53</version>
   </parent>
 
   <artifactId>ssh-slaves</artifactId>
@@ -27,7 +27,7 @@
   <properties>
     <revision>2</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361.1</jenkins.version>
+    <jenkins.version>2.375.1</jenkins.version>
     <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
   </properties>
 
@@ -101,7 +101,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
+        <artifactId>bom-2.375.x</artifactId>
         <version>1750.v0071fa_4c4a_e3</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
Update to Jenkins 2.375 (2.361.4 is minimum already).

### Submitter checklist

- [x] JIRA issue is well described
- [x] Appropriate autotests or explanation to why this change has no tests

