### PR TITLE
Fix start from workspace on drive D:

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
+++ b/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java
@@ -626,7 +626,7 @@ public class SSHLauncher extends ComputerLauncher {
                             String workingDirectory) throws IOException {
         session = connection.openSession();
         expandChannelBufferSize(session,listener);
-        String cmd = "cd \"" + workingDirectory + "\" && " + java + " " + getJvmOptions() + " -jar " + AGENT_JAR +
+        String cmd = java + " " + getJvmOptions() + " -jar " + "\"" + workingDirectory + SLASH_AGENT_JAR + "\"" +
                      getWorkDirParam(workingDirectory);
 
         //This will wrap the cmd with prefix commands and suffix commands if they are set.


### PR DESCRIPTION
When setup workspace for ex D:\workspace it failed, because on windows the command
`cd D:\workspace` 
does not work when current_dir on drive C:
It need to add option /D :
`cd /D D:\workspace` 
But more portable dont change working directory - intead of this simple start "remoting.jar" by absolute path.

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

