### PR TITLE
Enable Docker-based tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  useContainerAgent: false, // TestContainers
   configurations: [
     [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 17],


### PR DESCRIPTION
All of the Docker-based tests were being skipped in CI since (at least) #402.