### PR TITLE
Migrate `SSHLauncherTest` to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,18 +125,6 @@
       <artifactId>sshd</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.test</groupId>
-      <artifactId>docker-fixtures</artifactId>
-      <version>200.v22a_e8766731c</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!-- Jupiter/JUnit 5 testcontainers https://java.testcontainers.org/test_framework_integration/junit_5/ -->
     <dependency>
       <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
This amends #562. 

Apparently [docker-fixtures is no longer being maintained](https://github.com/jenkinsci/docker-fixtures/pull/122#issuecomment-3046351724). Turns out it was not required for this test in the first place, allowing a clean migration to JUnit5.

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Remove docker-fixtures
* Minor code cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
