### PR TITLE
[JENKINS-76219] Update SSH key fingerprints to use SHA-256

### DIFF
--- a/src/main/java/hudson/plugins/sshslaves/verifiers/HostKey.java
+++ b/src/main/java/hudson/plugins/sshslaves/verifiers/HostKey.java
@@ -25,7 +25,10 @@ package hudson.plugins.sshslaves.verifiers;
 
 import com.trilead.ssh2.KnownHosts;
 import java.io.Serializable;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Base64;
 
 /**
  * A representation of the SSH key provided by a remote host to verify itself
@@ -63,7 +66,14 @@ public final class HostKey implements Serializable {
     }
 
     public String getFingerprint() {
-        return KnownHosts.createHexFingerprint(getAlgorithm(), getKey());
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(getKey());
+            return "SHA256:" + Base64.getEncoder().encodeToString(digest);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 should always be available, but fallback to MD5 if not
+            return KnownHosts.createHexFingerprint(getAlgorithm(), getKey());
+        }
     }
 
     @Override

--- a/src/test/java/hudson/plugins/sshslaves/verifiers/HostKeyTest.java
+++ b/src/test/java/hudson/plugins/sshslaves/verifiers/HostKeyTest.java
@@ -1,0 +1,41 @@
+package hudson.plugins.sshslaves.verifiers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Steven Scheffler
+ */
+class HostKeyTest {
+
+    @Test
+    void testFingerprintUsesSHA256() {
+        // Example RSA key bytes (this is just test data)
+        byte[] keyBytes = "test-key-data".getBytes();
+        HostKey hostKey = new HostKey("ssh-rsa", keyBytes);
+
+        String fingerprint = hostKey.getFingerprint();
+
+        // Verify it starts with SHA256: prefix
+        assertTrue(fingerprint.startsWith("SHA256:"), "Fingerprint should use SHA256 format");
+
+        // Verify it's Base64 encoded after the prefix
+        String base64Part = fingerprint.substring(7); // Remove "SHA256:"
+        assertDoesNotThrow(
+                () -> Base64.getDecoder().decode(base64Part),
+                "Fingerprint should be valid Base64 after SHA256: prefix");
+    }
+
+    @Test
+    void testFingerprintFormat() {
+        byte[] keyBytes = "test-key-data".getBytes();
+        HostKey hostKey = new HostKey("ssh-rsa", keyBytes);
+
+        String fingerprint = hostKey.getFingerprint();
+
+        // Should match pattern: SHA256:[Base64]
+        assertTrue(fingerprint.matches("SHA256:[A-Za-z0-9+/=]+"), "Fingerprint should match SHA256:Base64 format");
+    }
+}


### PR DESCRIPTION
Replace MD5 fingerprint format with SHA-256 Base64 encoding to match OpenSSH 6.8+ behavior. Existing stored keys automatically use the new format without migration.

## Description

Updates SSH host key fingerprints to use SHA-256 with Base64 encoding instead of the deprecated MD5 hex format, aligning with OpenSSH 6.8+ standards.

**Old format:** `B5:A8:8D:C1:11:E5:C5:E0:53:62:DD:20:E1:DA:85`  
**New format:** `SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8`

### Changes Made

- Modified `HostKey.getFingerprint()` to use SHA-256 MessageDigest with Base64 encoding
- Added imports for `MessageDigest`, `NoSuchAlgorithmException`, and `Base64`
- Added fallback to MD5 if SHA-256 is unavailable (defensive programming)
- Created `HostKeyTest` to verify the new fingerprint format

### Backward Compatibility

**Fully backward compatible** - no data migration required:
- Existing keys stored as raw bytes in XML continue to work unchanged
- Fingerprints calculated on-demand from raw bytes, not stored
- Key verification uses byte comparison, not fingerprint strings
- All UI messages automatically display new format

### Testing done

- All existing tests pass (`mvn clean test`)
- Created new `HostKeyTest` with two test cases:
  - `testFingerprintUsesSHA256()` - Verifies SHA256: prefix and valid Base64 encoding
  - `testFingerprintFormat()` - Validates the complete format matches `SHA256:[Base64]` pattern
- Code formatted with Spotless (`mvn spotless:apply`)
- Full build successful (`mvn clean install`)
- Verified that `HostKeyHelper` stores raw key bytes, ensuring automatic migration
- Reviewed all verification strategy implementations to confirm they use raw byte comparison

**Manual Testing:**
The change affects fingerprint display in:
- Console log messages (e.g., "Key auto-trusted" messages)
- Trust key UI dialog when manually approving keys
- Both locations now show SHA256 format instead of MD5

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

### Related Issues

Fixes [JENKINS-76219](https://issues.jenkins.io/browse/JENKINS-76219) - Please update to using SHA-256 for SSH key fingerprints

### Additional Notes

This change only affects the **display format** of fingerprints. The underlying storage and verification mechanisms are unchanged, ensuring seamless operation with existing configurations. Users will see the new SHA-256 format immediately without any action required on their part.